### PR TITLE
Fix bug in drift time corrections 

### DIFF
--- a/src/GlueXSensitiveDetectorCDC.cc
+++ b/src/GlueXSensitiveDetectorCDC.cc
@@ -653,7 +653,7 @@ void GlueXSensitiveDetectorCDC::add_cluster(hit_vector_t &hits,
       polint(&fDrift_distance[index],
              &fDrift_time[index], 4, dradius_cm, &my_t_ns, &my_t_err);
    }
-   double tdrift_ns = my_t_ns / (1 - fBscale_par1 - fBscale_par2 * BmagT);
+   double tdrift_ns = my_t_ns / (fBscale_par1 + fBscale_par2 * BmagT);
 
    // Longitudinal diffusion 
 


### PR DESCRIPTION
This was identified by Mike Staib in the original hdgeant and is fixed in the current version of sim-recon.  This pull request applies a similar fix.