### PR TITLE
Davidl osx

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,13 +70,17 @@ DANALIBS = -L$(HALLD_HOME)/$(BMS_OSNAME)/lib -lHDGEOMETRY -lDANA \
            $(ROOTLIBS) \
            -lpthread -ldl
 
+ifdef ETROOT
+DANALIBS += -L$(ETROOT)/lib -let -let_remote
+endif
+
 G4shared_libs := $(wildcard $(G4ROOT)/lib64/*.so)
 
 INTYLIBS += -Wl,--whole-archive $(DANALIBS) -Wl,--no-whole-archive
 INTYLIBS += -fPIC -I$(HDDS_HOME) -I$(XERCESCROOT)/include
 INTYLIBS += -L${XERCESCROOT}/lib -lxerces-c
 INTYLIBS += -L$(G4TMPDIR) -lhdds
-INTYLIBS += -lboost_python $(shell python-config --libs)
+INTYLIBS += -lboost_python $(shell python-config --ldflags)
 INTYLIBS += -L$(G4ROOT)/lib64 $(patsubst $(G4ROOT)/lib64/lib%.so, -l%, $(G4shared_libs))
 
 .PHONY: all

--- a/GNUmakefile.OSX
+++ b/GNUmakefile.OSX
@@ -1,0 +1,150 @@
+# $Id: GNUmakefile,v 1.1 1999-01-07 16:05:42 gunter Exp $
+# --------------------------------------------------------------
+# GNUmakefile for examples module.  Gabriele Cosmo, 06/04/98.
+# --------------------------------------------------------------
+
+name := hdgeant4
+G4TARGET := $(name)
+G4EXLIB := true
+G4LIB_BUILD_SHARED := true
+G4WORKDIR := $(shell pwd)
+
+ifndef G4ROOT
+    $(error G4ROOT is not set, please set it and try again)
+endif
+
+ifndef G4SYSTEM
+    $(error Geant4 environment not set up, please source $(G4ROOT)/share/Geant4-10.2.2/geant4make/geant4make.sh and try again)
+endif
+
+ifdef DIRACXX_HOME
+    CPPFLAGS += -I$(DIRACXX_HOME) -DUSING_DIRACXX -L$(DIRACXX_HOME) -lDirac
+endif
+
+CPPFLAGS += -I$(HDDS_HOME) -I./src -I./src/G4fixes
+CPPFLAGS += -I./src/G4debug
+CPPFLAGS += -I$(HALLD_HOME)/$(BMS_OSNAME)/include
+CPPFLAGS += -I$(JANA_HOME)/include
+CPPFLAGS += -I$(shell root-config --incdir)
+CPPFLAGS += -I/usr/include/Qt
+CPPFLAGS += $(shell python-config --includes)
+CPPFLAGS += -Wno-unused-parameter
+CPPFLAGS += -DUSE_SSE2 -std=c++11
+#CPPFLAGS += -I/usr/include/Qt
+#CPPFLAGS += -DLINUX_CPUTIME_PROFILING=1
+#CPPFLAGS += -DCHECK_OVERLAPS_MM=1e-4
+CPPFLAGS += -DBYPASS_DRAWING_CLIPPED_VOLUMES
+CPPFLAGS += -DLAYERED_GEOMETRY_PICKING_EXTENSIONS
+#CPPFLAGS += -DG4UI_USE_EXECUTIVE
+CPPFLAGS += -DG4VIS_BUILD_OPENGL_DRIVER
+CPPFLAGS += -DG4VIS_BUILD_OPENGLX_DRIVER
+CPPFLAGS += -DG4MULTITHREADED
+#CPPFLAGS += -DFORCE_PARTICLE_TYPE_CHARGED_GEANTINO
+#CPPFLAGS += -DBP_DEBUG
+#CPPFLAGS += -DMOD_SPONCE
+#CPPFLAGS += -DDEBUG_PLACEMENT
+#CPPFLAGS += -DDEBUG_SECTIONPLANE
+#CPPFLAGS += -DDEBUG_SECTIONPLANE_ZAVE
+
+G4LIB_USE_GDML = 1
+CPPVERBOSE = 1
+#G4DEBUG = 1
+
+hdgeant4_sources := $(filter-out src/CobremsGeneration.cc, $(wildcard src/*.cc))
+G4fixes_sources := $(wildcard src/G4fixes/*.cc)
+G4debug_sources := $(wildcard src/G4debug/*.cc)
+HDDS_sources := $(HDDS_HOME)/XString.cpp $(HDDS_HOME)/XParsers.cpp $(HDDS_HOME)/hddsCommon.cpp
+
+ROOTLIBS = $(shell root-config --libs) -lGeom -lTMVA -lTreePlayer
+
+DANALIBS = -L$(HALLD_HOME)/$(BMS_OSNAME)/lib -lHDGEOMETRY -lDANA \
+           -lANALYSIS -lBCAL -lCCAL -lCDC -lCERE -lDIRC -lFCAL \
+           -lFDC -lFMWPC -lHDDM -lPAIR_SPECTROMETER -lPID -lRF \
+           -lSTART_COUNTER -lTAGGER -lTOF -lTPOL -lTRACKING \
+           -lTRIGGER -lDAQ -lTTAB -lEVENTSTORE -lKINFITTER \
+           -lxstream -lbz2 -lz \
+           $(shell mysql_config --libs) \
+           -L$(JANA_HOME)/lib -lJANA \
+           -L$(CCDB_HOME)/lib -lccdb \
+           -L$(EVIOROOT)/lib -levioxx -levio \
+           $(ROOTLIBS) \
+           -lpthread -ldl
+
+G4shared_libs := $(wildcard $(G4ROOT)/lib64/*.so)
+
+INTYLIBS +=  $(DANALIBS)
+INTYLIBS += -fPIC -I$(HDDS_HOME) -I$(XERCESCROOT)/include
+INTYLIBS += -L${XERCESCROOT}/lib -lxerces-c
+INTYLIBS += -L$(G4TMPDIR) -lhdds
+INTYLIBS += -lboost_python $(shell python-config --libs)
+INTYLIBS += -L$(G4ROOT)/lib64 $(patsubst $(G4ROOT)/lib64/lib%.so, -l%, $(G4shared_libs))
+
+.PHONY: all
+all: hdds cobrems sharedlib exe lib bin g4py
+
+include $(G4INSTALL)/config/binmake.gmk
+
+cobrems: $(G4TMPDIR)/libcobrems.so
+hdds:  $(G4TMPDIR)/libhdds.so
+
+CXXFLAGS = -O3 -fPIC -W -Wall -pedantic -Wno-non-virtual-dtor -Wno-long-long
+
+$(G4TMPDIR)/libcobrems.so: src/CobremsGeneration.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS)  \
+	-flat_namespace -undefined suppress \
+	-shared -o $@ $^ $(G4shared_libs) -lboost_python
+
+hdgeant4_objects := $(patsubst src/%.cc, $(G4TMPDIR)/%.o, $(hdgeant4_sources))
+G4fixes_objects := $(patsubst src/G4fixes/%.cc, $(G4TMPDIR)/%.o, $(G4fixes_sources))
+G4debug_objects := $(patsubst src/G4debug/%.cc, $(G4TMPDIR)/%.o, $(G4debug_sources))
+sharedlib: $(G4TMPDIR)/libhdgeant4.so
+
+$(G4TMPDIR)/libhdgeant4.so: $(hdgeant4_objects) $(G4fixes_objects) $(G4debug_objects)
+
+$(G4TMPDIR)/%.o: src/G4fixes/%.cc
+ifdef CPPVERBOSE
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+else
+	@echo Compiling $*.cc ...
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+endif
+
+$(G4TMPDIR)/%.o: src/G4debug/%.cc
+ifdef CPPVERBOSE
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+else
+	@echo Compiling $*.cc ...
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+endif
+
+HDDSDIR := $(G4TMPDIR)/hdds
+$(HDDSDIR)/%.o: $(HDDS_HOME)/%.cpp
+	@mkdir -p $(HDDSDIR)
+ifdef CPPVERBOSE
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+else
+	@echo Compiling $*.cc ...
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $^
+endif
+
+$(G4TMPDIR)/libhdds.so: $(patsubst $(HDDS_HOME)/%.cpp, $(HDDSDIR)/%.o, $(HDDS_sources))
+	@$(CXX) -flat_namespace -undefined suppress -shared -o $@ $^
+
+exe:
+	@mkdir -p $(G4LIBDIR)/$@
+
+g4py: $(G4LIBDIR)/../../../g4py/HDGeant4/libhdgeant4.so \
+      $(G4LIBDIR)/../../../g4py/Cobrems/libcobrems.so
+
+$(G4LIBDIR)/../../../g4py/HDGeant4/libhdgeant4.so: $(G4LIBDIR)/libhdgeant4.so
+	@rm -f $@
+	@cd g4py/HDGeant4 && ln -s ../../tmp/*/hdgeant4/libhdgeant4.so .
+
+$(G4LIBDIR)/../../../g4py/Cobrems/libcobrems.so: $(G4LIBDIR)/libcobrems.so 
+	@rm -f $@
+	@cd g4py/Cobrems && ln -s ../../tmp/*/hdgeant4/libcobrems.so .
+
+utils: $(G4BINDIR)/beamtree
+
+$(G4BINDIR)/beamtree: src/utils/beamtree.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ -L$(G4LIBDIR) -lhdgeant4 $(ROOTLIBS) -Wl,-rpath=$(G4LIBDIR)

--- a/README.OSX
+++ b/README.OSX
@@ -1,0 +1,112 @@
+
+
+Builing Geant4
+-----------------------
+Detailed instructions on how I built Geant4 for OS X are given at the bottom
+of this file. Note that for HDGeant4 you must set your G4ROOT environment variable.
+In my original build, I set a variable named simply G4. Just set G4ROOT to what
+I set G4 to in those instructions:
+
+> setenv G4ROOT $G4
+
+
+Install boost-python via homebrew
+----------------------------------
+If you don't already have homebrew installed, do it like this:
+(n.b. this command is for bash so if you are using csh or tcsh, just run bash
+and then run this from there. Homebrew will still be available for your (t)csh.
+
+> bash
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Install boost-python like this:
+
+$ brew install boost-python
+
+
+The files will all be linked in /usr/local/include and /usr/local/lib. You can
+exit your bash shell now if you started it just for installing this.
+
+
+Building HDGeant4
+-----------------------
+A special makefile was made to build for OSX. Run it with something like the following
+where the -j8 argument says to use 8 threads (adjust this to suit your hardware)
+
+make -f GNUmakefile.OSX -j8
+
+
+====================================================================================
+
+Build Geant4 on Mac OS X
+-----------------------------
+
+The following are instructions for how I build Geant4 on Mac OSX 10.11
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+Apr 10, 2017
+
+
+Here is how I built Geant4 10.03.p01 on OS X 10.11
+
+
+
+0.) Make sure a recent version of cmake is in your path. Using the 
+installer for OS X, it can be found here:
+
+> setenv PATH /Applications/CMake.app/Contents/bin/cmake:$PATH
+
+The compiler that comes with XCode 8 will work. As will clang3.8.0
+that I installed myself. Just make sure c++ points to the right place
+and that BMS_OSNAME is set correctly.
+
+
+
+1.) Unpack the source and create a build directory next to it as
+    suggested by the build instructions.
+
+> tar xzf geant4.10.03.p01.tar.gz 
+> mkdir geant4.10.03.p01.${BMS_OSNAME}-build
+> cd geant4.10.03.p01.${BMS_OSNAME}-build
+
+
+2.) Run cmake with appropriate flags to turn on GDML, OpenGL, and
+    raytracer. The GDML is so it can read geometry converted from
+	HDDS to GDML using the ROOT TGeoManager->Export() utility.
+	Note that GDML requires xerces and that it be given explicitly.
+
+> cmake -DCMAKE_INSTALL_PREFIX=/usr/local/geant4/geant4.10.03.p01.$BMS_OSNAME \
+		-DGEANT4_USE_GDML=ON \
+		-DXERCESC_ROOT_DIR=$XERCESCROOT \
+		-DGEANT4_USE_OPENGL_X11=ON \
+		-DGEANT4_USE_RAYTRACER_X11=ON \
+		-DGEANT4_BUILD_MULTITHREADED=ON \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		../geant4.10.03.p01
+
+
+
+3.) Run make (multi-threaded) followed by make install
+
+> make -j8
+> make install
+
+4.) Make sure the "data" directory containing all of the physics
+    process data files exists parallel to the installation directory.
+	 The directory: geant4.10.03.p01.$BMS_OSNAME/share/Geant4-10.2.2
+    will automatically be created. The data link, however, must be 
+	 created by hand:
+	 
+> cd ../geant4.10.03.p01.${BMS_OSNAME}/share/Geant4-10.3.1
+> ln -s ../../../data
+
+
+5.) Set up your environment to use this.
+
+setenv G4 /usr/local/geant4/geant4.10.03.p01.Darwin_macosx10.11-x86_64-llvm8.0.0
+source $G4/bin/geant4.csh $G4/bin
+source $G4/share/Geant4-10.*/geant4make/geant4make.csh $G4/share/Geant4-10.*/geant4make/
+

--- a/src/G4.10.03.p01fixes/BooleanProcessor.src
+++ b/src/G4.10.03.p01fixes/BooleanProcessor.src
@@ -1,0 +1,2445 @@
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor                            Date:    10.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Internal class for executing boolean operations           *
+ *           on Polyhedra                                              *
+ *                                                                     *
+ ***********************************************************************/
+
+//G.Barrand : begin
+#define BP_GEANT4
+
+#ifdef BP_GEANT4 //G.Barrand
+
+#include "G4Plane3D.hh"
+#include "G4Point3D.hh"
+#include "G4Normal3D.hh"
+typedef G4Plane3D HVPlane3D;
+typedef G4Point3D HVPoint3D;
+typedef G4Normal3D HVNormal3D;
+
+#else //BP_HEPVIS
+
+#define ExtNode          HEPVis_ExtNode
+#define ExtEdge          HEPVis_ExtEdge
+#define ExtFace          HEPVis_ExtFace
+#define FaceList         HEPVis_FaceList
+#define ExtPolyhedron    HEPVis_ExtPolyhedron
+#define BooleanProcessor HEPVis_BooleanProcessor
+
+#define HepPolyhedron SbPolyhedron
+#define G4Facet SbFacet
+
+#include <HEPVis/SbPlane.h>
+typedef HEPVis::SbPlane HVPlane3D;
+
+#endif
+
+//using namespace HepGeom;
+
+//#define BP_DEBUG
+
+//G.Barrand : end
+
+#define INITIAL_SIZE 200
+#define CRAZY_POINT  HVPoint3D(-10.e+6, -10.e+6, -10.e+6)
+//#define GRANULARITY  10.e+5;
+#define GRANULARITY  10.e+5  //G.Barrand : rm the trailing ;
+
+#define SWAP(A,B) w = A; A = B; B = w
+
+#define OP_UNION         0    // Operations
+#define OP_INTERSECTION  1
+#define OP_SUBTRACTION   2
+
+#define OUT_OF_PLANE     0    // Face vs face statuses
+#define ON_PLANE         1
+#define INTERSECTION     2
+#define EDGE             3
+#define NON_PLANAR_FACE  4
+
+#define UNKNOWN_FACE     0    // Face statuses 
+#define ORIGINAL_FACE   -1
+#define NEW_FACE        -2
+#define UNSUITABLE_FACE -3
+#define DEFECTIVE_FACE  -4
+
+// -------------------------------------------- Simplified STL vector ---
+//G.Barrand : begin
+#include <vector>
+using namespace std;
+/*
+template<class T>
+class vector {
+ private:
+  int cur_size, max_size;
+  T * v;
+
+ public:
+  vector(): cur_size(0), max_size(INITIAL_SIZE), v(new T[INITIAL_SIZE]) {}
+  ~vector() { delete [] v; }  
+
+  void      clear()                 { cur_size = 0; }
+  int       size()            const { return cur_size; }
+  T &       operator[](int i)       { return v[i]; }
+  const T & operator[](int i) const { return v[i]; }
+  T &       front()                 { return v[0]; }
+  const T & front()           const { return v[0]; }
+  T &       back()                  { return v[cur_size-1]; }
+  const T & back()            const { return v[cur_size-1]; }
+  void      pop_back()              { cur_size--; }
+  void      push_back(const T & a) {
+    if (cur_size == max_size) {
+      T * w     = v;
+      max_size *= 2;
+      v         = new T[max_size];
+      for (int i=0; i<cur_size; i++) v[i] = w[i];
+      v[cur_size++] = a;
+      delete [] w;
+    }else{
+      v[cur_size++] = a;
+    }
+  }
+};
+*/
+//G.Barrand : end
+
+// ---------------------------------------------------- Extended node ---
+class ExtNode {
+ public:
+  HVPoint3D v;
+  int        s;
+
+ public: 
+  ExtNode(HVPoint3D vertex=HVPoint3D(), int status=0)
+    : v(vertex), s(status) {}
+  ~ExtNode() {}
+
+  ExtNode(const ExtNode & node) : v(node.v), s(node.s) {}
+
+  ExtNode & operator=(const ExtNode & node) {
+    if (&node == this) return *this;
+    v = node.v;
+    s = node.s;
+    return *this;
+  }
+};
+
+// ---------------------------------------------------- Extended edge ---
+class ExtEdge {
+ public:
+  int       i1, i2;           // end points
+  int       iface1;           // native face
+  int       iface2;           // neighbouring face
+  int       ivis;             // visibility: +1 (visible), -1 (invisible)
+  int       inext;            // index of next edge 
+
+ public:
+  ExtEdge(int k1=0, int k2=0, int kface1=0, int kface2=0, int kvis=0) :
+    i1(k1), i2(k2), iface1(kface1), iface2(kface2), ivis(kvis), inext(0) {}
+
+  ~ExtEdge() {};
+
+  ExtEdge(const ExtEdge & edge) :
+    i1(edge.i1), i2(edge.i2), iface1(edge.iface1), iface2(edge.iface2),
+    ivis(edge.ivis), inext(edge.inext) {}
+
+  ExtEdge & operator=(const ExtEdge & edge) {
+    if (&edge == this) return *this;
+    i1     = edge.i1;
+    i2     = edge.i2;
+    iface1 = edge.iface1;
+    iface2 = edge.iface2;
+    ivis   = edge.ivis;
+    inext  = edge.inext;
+    return *this;
+  }
+
+  void invert() {
+    int w;
+    SWAP(i1, i2);
+  }
+};
+
+// ---------------------------------------------------- Extended face ---
+class ExtFace {
+ private:
+  std::vector<ExtEdge>& edges; //G.Barrand
+ public:
+  int        iedges[4];        // indices of original edges
+  HVPlane3D plane;            // face plane
+  double     rmin[3], rmax[3]; // bounding box
+  int        iold;             // head of the list of the original edges
+  int        inew;             // head of the list of the new edges
+  int        iprev;            // index of previous face 
+  int        inext;            // index of next face 
+
+ public:
+  //G.Barrand : ExtFace(int iedge=0) : iold(iedge), inew(0), iprev(iprev), inext(0) {}
+  ExtFace(std::vector<ExtEdge>& a_edges,int iedge)
+  : edges(a_edges), iold(iedge), inew(0), iprev(0), inext(0) {
+    //G.Barrand : initialize arrays to quiet valgrind.
+   {for (int i=0; i<4; i++) { iedges[i] = 0; }}
+   {for (int i=0; i<3; i++) { rmin[i] = 0; rmax[i] = 0; }}
+  }
+  ~ExtFace() {}
+
+  ExtFace(const ExtFace & face) :
+    edges(face.edges), //G.Barrand
+    plane(face.plane), iold(face.iold), inew(face.inew),
+    iprev(face.iprev), inext(face.inext)
+  { 
+    int i;
+    for (i=0; i<4; i++) { iedges[i] = face.iedges[i]; }
+    for (i=0; i<3; i++) { rmin[i] = face.rmin[i]; rmax[i] = face.rmax[i]; }
+  }
+
+  ExtFace & operator=(const ExtFace & face) {
+    if (&face == this) return *this;
+    //FIXME : edges(face.edges) ???? //G.Barrand
+    int i;
+    for (i=0; i<4; i++) { iedges[i] = face.iedges[i]; }
+    plane  = face.plane;
+    for (i=0; i<3; i++) { rmin[i] = face.rmin[i]; rmax[i] = face.rmax[i]; }
+    iold   = face.iold;
+    inew   = face.inew;
+    iprev  = face.iprev;
+    inext  = face.inext;
+    return *this;
+  }
+
+  void invert();
+};
+
+// ---------------------------------------------------- Global arrays ---
+//G.Barrand : MacIntel : crash with g++-4.0.1 with -O on some subtract.
+//            Anyway static of objects is proved to be not safe.
+//            We put the below vector as members of BooleanProcessor.
+//GB static std::vector<ExtNode> nodes;        // vector of nodes
+//GB static std::vector<ExtEdge> edges;        // vector of edges
+//GB static std::vector<ExtFace> faces;        // vector of faces
+
+// ---------------------------------------------------- List of faces ---
+class FaceList {
+ private:
+  std::vector<ExtFace>& faces; //G.Barrad : end
+ private:
+  int ihead;
+  int ilast;
+
+ public:
+  //G.Barrand : FaceList() : ihead(0), ilast(0) {}
+  FaceList(std::vector<ExtFace>& a_faces) : faces(a_faces),ihead(0),ilast(0) {}
+  ~FaceList() {}
+
+  void clean() { ihead = 0; ilast = 0; }  
+  int front()  { return ihead; }
+
+  void push_back(int i) {
+    if (ilast == 0) { ihead = i; } else { faces[ilast].inext = i; } 
+    ExtFace& face = faces[i]; //G.Barrand : optimize.
+    face.iprev = ilast;
+    face.inext = 0;
+    ilast = i;
+  }
+
+  void remove(int i) {
+    ExtFace& face = faces[i]; //G.Barrand : optimize.
+    if (ihead == i) {
+      ihead = face.inext;
+    }else{
+      faces[face.iprev].inext = face.inext;
+    }
+    if (ilast == i) {
+      ilast = face.iprev; 
+    }else{
+      faces[face.inext].iprev = face.iprev;
+    }
+    face.iprev = 0;
+    face.inext = 0;
+  }
+};
+
+// --------------------- Polyhedron with extended access to
+//                       its members from the BooleanProcessor class ---
+class ExtPolyhedron : public HepPolyhedron {
+  friend class BooleanProcessor;
+  virtual HepPolyhedron& operator = (const HepPolyhedron& from) {
+    return HepPolyhedron::operator = (from);
+  }
+};
+
+// ----------------------------------------- Boolean processor class ---
+class BooleanProcessor {
+ private:
+  static G4ThreadLocal int ishift; //G.Barrand
+  std::vector<ExtNode> nodes;        // vector of nodes //G.Barrand
+  std::vector<ExtEdge> edges;        // vector of edges //G.Barrand
+  std::vector<ExtFace> faces;        // vector of faces //G.Barrand
+ private:
+  int             processor_error;   // is set in case of error
+  int             operation;  // 0 (union), 1 (intersection), 2 (subtraction)
+  int             ifaces1, ifaces2;  // lists of faces
+  int             iout1,   iout2;    // lists of faces with status "out"
+  int             iunk1,   iunk2;    // lists of faces with status "unknown"
+  double          rmin[3], rmax[3];  // intersection of bounding boxes
+  double          del;               // precision (tolerance)   
+
+  FaceList        result_faces;      // list of accepted faces
+  FaceList        suitable_faces;    // list of suitable faces
+  FaceList        unsuitable_faces;  // list of unsuitable faces
+  FaceList        unknown_faces;     // list of unknown faces
+
+  vector<int>     external_contours; // heads of external contours
+  vector<int>     internal_contours; // heads of internal contours
+
+ private:
+  void   takePolyhedron(const HepPolyhedron & p, double, double, double);
+  double findMinMax();
+  void   selectOutsideFaces(int & ifaces, int & iout);
+  int    testFaceVsPlane(ExtEdge & edge); 
+  void   renumberNodes(int & i1, int & i2, int & i3, int & i4);
+  int    testEdgeVsEdge(ExtEdge & edge1, ExtEdge & edge2); 
+  void   removeJunkNodes() { while(nodes.back().s != 0) nodes.pop_back(); }
+  void   divideEdge(int & i1, int & i2);
+  void   insertEdge(const ExtEdge & edge);
+  void   caseII(ExtEdge & edge1, ExtEdge & edge2);
+  void   caseIE(ExtEdge & edge1, ExtEdge & edge2);
+  void   caseEE(ExtEdge & edge1, ExtEdge & edge2);
+  void   testFaceVsFace(int iface1, int iface2); 
+  void   invertNewEdges(int iface);
+  void   checkDoubleEdges(int iface);
+  void   assembleFace(int what, int iface);
+  void   assembleNewFaces(int what, int ihead);
+  void   initiateLists();
+  void   assemblePolyhedra();
+  void   findABC(double x1, double y1, double x2, double y2,
+                 double &a, double &b, double &c) const;
+  int    checkDirection(double *x, double *y) const;
+  int    checkIntersection(int ix, int iy, int i1, int i2) const;
+  void   mergeContours(int ix, int iy, int kext, int kint);
+  int    checkTriangle(int iedge1, int iedge2, int ix, int iy) const;
+  void   triangulateContour(int ix, int iy, int ihead);
+  void   modifyReference(int iface, int i1, int i2, int iref);
+  void   triangulateFace(int iface);
+  HepPolyhedron createPolyhedron();
+
+ public:
+  //G.Barrand : BooleanProcessor() {}
+  BooleanProcessor() //G.Barrand
+  :processor_error(0)  // The next few fields are work space, initialised
+  ,operation(0)        // here to prevent Coverity warnings.
+  ,ifaces1(0)          // "
+  ,ifaces2(0)          // "
+  ,iout1(0)            // "
+  ,iout2(0)            // "
+  ,iunk1(0)            // "
+  ,iunk2(0)            // "
+  ,del(0.)             // "
+  ,result_faces(faces)
+  ,suitable_faces(faces)
+  ,unsuitable_faces(faces)
+  ,unknown_faces(faces)
+  {  // rmin, rmax also initialised here to prevent Coverity warnings.
+    for (int i = 0; i < 3; i++) {
+      rmin[i] = 0.;
+      rmax[i] = 0.;
+    }
+  }
+
+  ~BooleanProcessor() {}
+
+  HepPolyhedron execute(int op,
+                        const HepPolyhedron &a,
+                        const HepPolyhedron &b,
+                        int& err);
+
+  void draw();
+  void draw_edge(int, int);
+  void draw_contour(int, int, int);
+  void draw_faces(int, int, int);
+  void print_face(int);
+  void print_edge(int);
+  int get_processor_error() const {return processor_error;}
+
+  void dump(); //G.Barrand
+  static int get_shift(); //G.Barrand
+  static void set_shift(int a_shift); //G.Barrand
+  static int get_num_shift(); //G.Barrand
+};
+
+inline void ExtFace::invert()
+/***********************************************************************
+ *                                                                     *
+ * Name: ExtFace::invert()                           Date:    28.02.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Invert face                                               *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iEprev, iEcur, iEnext;
+
+  iEprev = 0; iEcur = iold;
+  while (iEcur > 0) {
+    ExtEdge& edge = edges[iEcur]; //G.Barrand : optimize.
+    edge.invert();
+    iEnext = edge.inext;
+    edge.inext = iEprev;
+    iEprev = iEcur;
+    iEcur  = iEnext;
+  }
+  if (iold > 0) iold = iEprev;
+
+  iEprev = 0; iEcur = inew;
+  while (iEcur > 0) {
+    ExtEdge& edge = edges[iEcur]; //G.Barrand : optimize.
+    edge.invert();
+    iEnext = edge.inext;
+    edge.inext = iEprev;
+    iEprev = iEcur;
+    iEcur  = iEnext;
+  }
+  if (inew > 0) inew = iEprev;
+
+#ifdef BP_GEANT4 //G.Barrand
+  plane = HVPlane3D(-plane.a(), -plane.b(), -plane.c(), -plane.d());
+#else
+  plane = HVPlane3D(-plane.getNormal(), -plane.getDistanceFromOrigin());
+#endif
+}
+
+void BooleanProcessor::takePolyhedron(const HepPolyhedron & p,
+                                      double dx, double dy, double dz)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::takePolyhedron            Date:    16.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Transfer Polyhedron to internal representation            *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int i = 0, k = 0, nnode = 0, iNodes[5] = {0,0,0,0,0}, iVis[4] = {0,0,0,0},
+  iFaces[4] = {0,0,0,0};
+  int dnode = nodes.size() - 1;
+  int dface = faces.size() - 1;
+
+  //   S E T   N O D E S
+
+  //  for (i=1; i <= p.GetNoVertices(); i++) {  
+  //    nodes.push_back(ExtNode(p.GetVertex(i)));
+  //  }
+
+  HVPoint3D ppp;        
+  for (i=1; i <= p.GetNoVertices(); i++) {  
+#ifdef BP_GEANT4 //G.Barrand
+    ppp = p.GetVertex(i);
+    ppp.setX(ppp.x()+dx);
+    ppp.setY(ppp.y()+dy);
+    ppp.setZ(ppp.z()+dz);
+#else
+    ppp = p.GetVertexFast(i);
+    ppp += HVPoint3D(dx,dy,dz);
+#endif
+    nodes.push_back(ExtNode(ppp));
+  }
+
+  //   S E T   F A C E S
+
+  for (int iface=1; iface <= p.GetNoFacets(); iface++) {
+    faces.push_back(ExtFace(edges,edges.size()));
+
+    //   S E T   F A C E   N O D E S
+
+    p.GetFacet(iface, nnode, iNodes, iVis, iFaces);
+    for (i=0; i<nnode; i++) {
+      //if (iNodes[i] < 1 || iNodes[i] > p.GetNoVertices()) processor_error = 1;
+      //if (iFaces[i] < 1 || iFaces[i] > p.GetNoFacets())   processor_error = 1;
+
+      if (iNodes[i] < 1 || iNodes[i] > p.GetNoVertices()) { //G.Barrand
+        processor_error = 1;
+#ifdef BP_DEBUG
+        G4cerr
+          << "BooleanProcessor::takePolyhedron : problem 1."
+          << G4endl;
+#endif
+      }
+      if (iFaces[i] < 1 || iFaces[i] > p.GetNoFacets()) { //G.Barrand
+        processor_error = 1;
+#ifdef BP_DEBUG
+        G4cerr
+          << "BooleanProcessor::takePolyhedron : problem 2."
+          << G4endl;
+#endif
+      }
+      iNodes[i] += dnode;
+      iFaces[i] += dface;
+    }
+
+    //   S E T   E D G E S
+
+    iNodes[nnode] = iNodes[0];
+    faces.back().iedges[3] = 0;
+    for (i=0; i<nnode; i++) {
+      faces.back().iedges[i] = edges.size();
+      edges.push_back(ExtEdge(iNodes[i], iNodes[i+1],
+                              iface+dface, iFaces[i], iVis[i]));
+      edges.back().inext     = edges.size();
+    }
+    edges.back().inext = 0;
+
+    //   S E T   F A C E   M I N - M A X
+
+    ExtFace& face = faces.back();     //G.Barrand : optimize.
+    for (i=0; i<3; i++) {
+      face.rmin[i] = nodes[iNodes[0]].v[i];
+      face.rmax[i] = nodes[iNodes[0]].v[i];
+    }
+    for (i=1; i<nnode; i++) {
+      ExtNode& node = nodes[iNodes[i]]; //G.Barrand : optimize.
+      for (k=0; k<3; k++) {
+        if (face.rmin[k] > node.v[k])
+            face.rmin[k] = node.v[k];
+        if (face.rmax[k] < node.v[k])
+            face.rmax[k] = node.v[k];
+      }
+    }
+
+    //   S E T   F A C E   P L A N E
+
+    HVNormal3D n = (nodes[iNodes[2]].v-nodes[iNodes[0]].v).cross
+                    (nodes[iNodes[3]].v-nodes[iNodes[1]].v);
+    HVPoint3D  point(0,0,0);
+    
+    for (i=0; i<nnode; i++) { point += nodes[iNodes[i]].v; }
+    if (nnode > 1) point *= (1./nnode);
+    //G.Barrand : faces.back().plane = HVPlane3D(n.unit(), point);
+    faces.back().plane = HVPlane3D(n, point); //G.Barrand
+
+    //   S E T   R E F E R E N C E   T O   T H E   N E X T   F A C E
+
+    faces.back().inext = faces.size(); 
+  }
+  faces.back().inext = 0; 
+}
+
+double BooleanProcessor::findMinMax()
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::findMinMax                Date:    16.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Find min-max (bounding) boxes for polyhedra               *
+ *                                                                     *
+ ***********************************************************************/
+{
+  if (ifaces1 == 0 || ifaces2 == 0) return 0;
+
+  int    i, iface;
+  double rmin1[3], rmax1[3];
+  double rmin2[3], rmax2[3];
+
+  //   F I N D   B O U N D I N G   B O X E S
+
+  for (i=0; i<3; i++) {
+    rmin1[i] = faces[ifaces1].rmin[i];
+    rmax1[i] = faces[ifaces1].rmax[i];
+    rmin2[i] = faces[ifaces2].rmin[i];
+    rmax2[i] = faces[ifaces2].rmax[i];
+  }
+
+  iface = faces[ifaces1].inext;
+  while(iface > 0) {
+    ExtFace& face = faces[iface]; //G.Barrand
+    for (i=0; i<3; i++) {
+      if (rmin1[i] > face.rmin[i]) rmin1[i] = face.rmin[i];
+      if (rmax1[i] < face.rmax[i]) rmax1[i] = face.rmax[i];
+    }
+    iface = face.inext;
+  }
+
+  iface = faces[ifaces2].inext;
+  while(iface > 0) {
+    ExtFace& face = faces[iface]; //G.Barrand
+    for (i=0; i<3; i++) {
+      if (rmin2[i] > face.rmin[i]) rmin2[i] = face.rmin[i];
+      if (rmax2[i] < face.rmax[i]) rmax2[i] = face.rmax[i];
+    }
+    iface = face.inext;
+  }
+
+  //   F I N D   I N T E R S E C T I O N   O F   B O U N D I N G   B O X E S
+
+  for (i=0; i<3; i++) {
+    rmin[i] = (rmin1[i] > rmin2[i]) ? rmin1[i] : rmin2[i]; 
+    rmax[i] = (rmax1[i] < rmax2[i]) ? rmax1[i] : rmax2[i]; 
+  }
+
+  //   F I N D   T O L E R A N C E
+
+  double del1 = 0;
+  double del2 = 0;
+  for (i=0; i<3; i++) {
+    if ((rmax1[i]-rmin1[i]) > del1) del1 = rmax1[i]-rmin1[i]; 
+    if ((rmax2[i]-rmin2[i]) > del2) del2 = rmax2[i]-rmin2[i]; 
+  }
+  return ((del1 < del2) ? del1 : del2) / GRANULARITY;
+}
+
+void BooleanProcessor::selectOutsideFaces(int & ifaces, int & iout)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::selectOutsideFaces        Date:    10.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Preselection of outside faces                             *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int i, outflag, iface = ifaces, *prev;
+  HVPoint3D mmbox[8] = { HVPoint3D(rmin[0],rmin[1],rmin[2]),
+                               HVPoint3D(rmax[0],rmin[1],rmin[2]),
+                               HVPoint3D(rmin[0],rmax[1],rmin[2]),
+                               HVPoint3D(rmax[0],rmax[1],rmin[2]),
+                               HVPoint3D(rmin[0],rmin[1],rmax[2]),
+                               HVPoint3D(rmax[0],rmin[1],rmax[2]),
+                               HVPoint3D(rmin[0],rmax[1],rmax[2]),
+                               HVPoint3D(rmax[0],rmax[1],rmax[2]) };
+  prev = &ifaces;
+  while (iface > 0) {
+
+    //   B O U N D I N G   B O X   vs  B O U N D I N G   B O X 
+
+    outflag = 0;
+    ExtFace& face = faces[iface]; //G.Barrand : optimize.
+    for (i=0; i<3; i++) {
+      if (face.rmin[i] > rmax[i] + del) { outflag = 1; break; }
+      if (face.rmax[i] < rmin[i] - del) { outflag = 1; break; }
+    }
+
+    //   B O U N D I N G   B O X   vs  P L A N E
+
+    if (outflag == 0) {
+      int npos = 0, nneg = 0;
+      double d;
+      for (i=0; i<8; i++) {
+        d = face.plane.distance(mmbox[i]); //G.Barrand : optimize
+        if (d > +del) npos++;
+        if (d < -del) nneg++;
+      }
+      if (npos == 8 || nneg == 8) outflag = 1;
+    }
+
+    //   U P D A T E   L I S T S
+
+    if (outflag == 1) {
+      *prev = face.inext;
+      face.inext = iout;
+      iout = iface;
+    }else{
+      prev = &face.inext;
+    }
+
+    iface = *prev;
+  }
+}
+
+int BooleanProcessor::testFaceVsPlane(ExtEdge & edge)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::testFaceVsPlane           Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Find result of intersection of face by plane              *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int        iface = edge.iface1;
+  HVPlane3D plane = faces[edge.iface2].plane;
+  int        i, nnode, npos = 0, nneg = 0, nzer = 0;
+  double     dd[5];
+
+  //   F I N D   D I S T A N C E S
+
+  nnode = (faces[iface].iedges[3] == 0) ? 3 : 4;
+  for (i=0; i<nnode; i++) {
+    dd[i] = plane.distance(nodes[edges[faces[iface].iedges[i]].i1].v);
+    if (dd[i] > del) {
+      npos++; 
+    }else if (dd[i] < -del) {
+      nneg++;
+    }else{
+      nzer++; dd[i] = 0;
+    }  
+  }
+
+  //   S O M E   S I M P L E   C A S E S  ( N O   I N T E R S E C T I O N )
+
+  if (npos == nnode || nneg == nnode)   return OUT_OF_PLANE;
+  if (nzer == 1     && nneg == 0)       return OUT_OF_PLANE;
+  if (nzer == 1     && npos == 0)       return OUT_OF_PLANE;
+  if (nzer == nnode)                    return ON_PLANE;
+  if (nzer == 3)                        return NON_PLANAR_FACE;
+
+  //   F I N D   I N T E R S E C T I O N
+
+  int       ie1 = 0, ie2 = 0, s1 = 0, s2 = 0, status, nint = 0; 
+  enum      { PLUS_MINUS, MINUS_PLUS, ZERO_ZERO, ZERO_PLUS, ZERO_MINUS };
+
+  dd[nnode] = dd[0];
+  for (i=0; i<nnode; i++) {
+    if (dd[i] > 0) {
+      if (dd[i+1] >= 0) continue;
+      status = PLUS_MINUS;
+    }else if (dd[i] < 0) {
+      if (dd[i+1] <= 0) continue;
+      status = MINUS_PLUS;
+    }else{   
+      status = ZERO_ZERO;
+      if (dd[i+1] > 0) status = ZERO_PLUS;
+      if (dd[i+1] < 0) status = ZERO_MINUS;
+    }
+    switch (nint) {
+    case 0:
+      ie1 = i; s1 = status; nint++; break;
+    case 1:
+      ie2 = i; s2 = status; nint++; break;
+    default:
+      return NON_PLANAR_FACE;
+    }
+  }
+  if (nint != 2)                        return NON_PLANAR_FACE;
+
+  //   F O R M   I N T E R S E C T I O N   S E G M E N T
+
+  if (s1 != ZERO_ZERO && s2 != ZERO_ZERO) {
+    if (s1 == s2)                       return NON_PLANAR_FACE;
+    int     iedge, i1 = 0, i2 = 0, ii[2];
+    double  d1 = 0., d2 = 0., d3 = 0.;
+    ii[0] = ie1; ii[1] = ie2;
+    for (i=0; i<2; i++) {
+      iedge = faces[iface].iedges[ii[i]];
+      while (iedge > 0) {
+        i1 = edges[iedge].i1;
+        i2 = edges[iedge].i2;
+   
+        d1 = plane.distance(nodes[i1].v);
+        d2 = plane.distance(nodes[i2].v);
+        if (d1 > del) {
+          if (d2 < -del) { ii[i] = nodes.size(); break; } // +-
+        }else if (d1 < -del) {
+          if (d2 >  del) { ii[i] = nodes.size(); break; } // -+
+        }else{ 
+          ii[i] = i1; break;                              // 0+ or 0-
+        }
+        iedge = edges[iedge].inext;
+      }
+      if (ii[i] == (int)nodes.size()) {
+        d3 = d2-d1; d1 = d1/d3; d2 = d2/d3;
+        nodes.push_back(ExtNode(d2*nodes[i1].v-d1*nodes[i2].v, iedge));
+      }  
+    }
+    edge.inext = 0;
+    if (s1 == MINUS_PLUS || s1 == ZERO_PLUS) {
+      edge.i1 = ii[1];
+      edge.i2 = ii[0];
+    }else{
+      edge.i1 = ii[0];
+      edge.i2 = ii[1];
+    }
+    return INTERSECTION;
+  }else{
+    if (npos == nneg)                   return NON_PLANAR_FACE;
+    edge.inext = (s1 == ZERO_ZERO) ? ie1+1 : ie2+1;
+    if (s1 == ZERO_PLUS || s2 == ZERO_MINUS) {
+      edge.i1 = edges[faces[iface].iedges[ie2]].i1;
+      edge.i2 = edges[faces[iface].iedges[ie1]].i1;
+    }else{
+      edge.i1 = edges[faces[iface].iedges[ie1]].i1;
+      edge.i2 = edges[faces[iface].iedges[ie2]].i1;
+    }
+    return EDGE;
+  }
+}
+
+void BooleanProcessor::renumberNodes(int & i1, int & i2, int & i3, int & i4)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::renumberNodes             Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Renumber nodes and remove last temporary node.            *
+ *           Remark: In principal this routine can be replaced just    *
+ *           with i1 = i2;                                             *
+ *           Removal of temporary nodes provides additional control    *
+ *           on number of nodes, that is very useful for debugging.    *
+ *                                                                     *
+ ***********************************************************************/
+{
+  if (i1 == i2) return;
+  if (nodes[i1].s == 0 || nodes.back().s == 0) { i1 = i2; return; }
+
+  int ilast = nodes.size()-1;
+  if (i1 == ilast) { i1 = i2; nodes.pop_back(); return; }
+  if (i2 == ilast) { i2 = i1; }
+  if (i3 == ilast) { i3 = i1; }
+  if (i4 == ilast) { i4 = i1; }
+  nodes[i1] = nodes.back(); i1 = i2; nodes.pop_back();
+}
+
+int BooleanProcessor::testEdgeVsEdge(ExtEdge & edge1, ExtEdge & edge2)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::testEdgeVsEdge            Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Find common part of two edges                             *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int    i, ii = 0;
+  double d, dd = 0.;
+
+  for (i=0; i<3; i++) {
+    d = nodes[edge1.i1].v[i]-nodes[edge1.i2].v[i];
+    if (d < 0.) d = -d; 
+    if (d > dd) { dd = d; ii = i; }
+  }
+  double t1 = nodes[edge1.i1].v[ii];
+  double t2 = nodes[edge1.i2].v[ii];
+  double t3 = nodes[edge2.i1].v[ii];
+  double t4 = nodes[edge2.i2].v[ii];
+  if (t2-t1 < 0.) { t1 = -t1; t2 = -t2; t3 = -t3; t4 = -t4; }
+ 
+  if (t3 <= t1+del || t4 >= t2-del) return 0;
+  if (t3 > t2+del) {
+    renumberNodes(edge2.i1, edge1.i2, edge1.i1, edge2.i2);
+  }else if (t3 < t2-del) {
+    renumberNodes(edge1.i2, edge2.i1, edge1.i1, edge2.i2);
+  }
+  if (t4 < t1-del) {
+    renumberNodes(edge2.i2, edge1.i1, edge1.i2, edge2.i1);
+  }else if (t4 > t1+del) {
+    renumberNodes(edge1.i1, edge2.i2, edge1.i2, edge2.i1);
+  }
+  return 1;
+}
+
+void BooleanProcessor::divideEdge(int & i1, int & i2)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::divideEdge                Date:    24.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Unify the nodes and divide edge on two parts by the node. *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iedges[2];
+  iedges[0] = nodes[i1].s;
+  iedges[1] = nodes[i2].s;
+
+  //   U N I F Y   N O D E S
+  
+  if      (i1 < i2) { i2 = i1; }
+  else if (i1 > i2) { i1 = i2; }
+  else              { iedges[1] = 0; }  
+  if (iedges[0] == iedges[1]) return;
+
+  int ie1, ie2, inode = i1;
+  nodes[inode].s = 0;
+  for (int i=0; i<2; i++) {
+
+    //   F I N D   C O R R E S P O N D I N G   E D G E
+
+    if ((ie1 = iedges[i]) == 0) continue;
+    ie2 = faces[edges[ie1].iface2].iedges[0];
+    while (ie2 > 0) {
+      if (edges[ie2].i1 == edges[ie1].i2 &&
+          edges[ie2].i2 == edges[ie1].i1) break;
+      ie2 = edges[ie2].inext;
+    }
+
+    //   D I V I D E   E D G E S
+    
+    edges.push_back(edges[ie1]);
+    edges[ie1].inext = edges.size() - 1;
+    edges[ie1].i2    = inode;
+    edges.back().i1  = inode;
+    
+    edges.push_back(edges[ie2]);
+    edges[ie2].inext = edges.size() - 1;
+    edges[ie2].i2    = inode;
+    edges.back().i1  = inode;
+  } 
+}
+
+void BooleanProcessor::insertEdge(const ExtEdge & edge)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::insertEdge                Date:    24.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Insert edge to the list of new edges                      *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iface = edge.iface1;
+  edges.push_back(edge);
+  edges.back().inext = faces[iface].inew;
+  faces[iface].inew  = edges.size() - 1;
+}
+
+void BooleanProcessor::caseII(ExtEdge & edge1, ExtEdge & edge2)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::caseII                    Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Intersection/Intersection case                            *
+ *                                                                     *
+ ***********************************************************************/
+{
+  divideEdge(edge1.i1, edge2.i2);
+  divideEdge(edge1.i2, edge2.i1);
+  edge1.ivis = 1;
+  edge2.ivis = 1;
+  insertEdge(edge1);
+  insertEdge(edge2);
+}
+
+void BooleanProcessor::caseIE(ExtEdge &, ExtEdge &)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::caseIE                    Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Intersection/Edge-touch case                              *
+ *                                                                     *
+ ***********************************************************************/
+{
+  processor_error = 1;
+#ifdef BP_DEBUG
+  G4cout
+    << "BooleanProcessor::caseIE : unimplemented case"
+    << G4endl;
+#endif
+}
+
+void BooleanProcessor::caseEE(ExtEdge &, ExtEdge &)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::caseEE                    Date:    19.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Edge-touch/Edge-touch case                                *
+ *                                                                     *
+ ***********************************************************************/
+{
+  processor_error = 1;
+#ifdef BP_DEBUG
+  G4cout
+    << "BooleanProcessor::caseEE : unimplemented case"
+    << G4endl;
+#endif
+}
+
+void BooleanProcessor::testFaceVsFace(int iface1, int iface2)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::testFaceVsFace            Date:    11.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Find result (an edge) of intersection of two faces        *
+ *                                                                     *
+ ***********************************************************************/
+{
+  ExtEdge edge1, edge2;
+  int     irep1, irep2;
+
+  //   M I N - M A X
+
+ {const ExtFace& face_1 = faces[iface1]; //G.Barrand : optimize
+  const ExtFace& face_2 = faces[iface2];
+  for (int i=0; i<3; i++) {
+    if (face_1.rmin[i] > face_2.rmax[i] + del) return;
+    if (face_1.rmax[i] < face_2.rmin[i] - del) return;
+  }}
+
+  //   F A C E - 1   vs   P L A N E - 2
+
+  edge1.iface1 = iface1;
+  edge1.iface2 = iface2;
+  irep1        = testFaceVsPlane(edge1); 
+  if (irep1 == OUT_OF_PLANE || irep1 == ON_PLANE) {
+    removeJunkNodes();
+    return;
+  }
+
+  //   F A C E - 2   vs   P L A N E - 1
+
+  edge2.iface1 = iface2;
+  edge2.iface2 = iface1;
+  irep2        = testFaceVsPlane(edge2); 
+  if (irep2 == OUT_OF_PLANE || irep2 == ON_PLANE) {
+    removeJunkNodes();
+    return;
+  }
+
+  //   C H E C K   F O R   N O N P L A N A R   F A C E 
+
+  if (irep1 == NON_PLANAR_FACE || irep2 == NON_PLANAR_FACE) {
+    removeJunkNodes();
+    return;
+  }
+
+  //   F I N D   I N T E R S E C T I O N   P A R T
+
+  if (testEdgeVsEdge(edge1, edge2) == 0) return;
+
+  //   C O N S I D E R   D I F F E R E N T   C A S E S  
+
+  if (irep1 == INTERSECTION && irep2 == INTERSECTION) caseII(edge1, edge2);
+  if (irep1 == INTERSECTION && irep2 == EDGE)         caseIE(edge1, edge2);
+  if (irep1 == EDGE         && irep2 == INTERSECTION) caseIE(edge2, edge1);
+  if (irep1 == EDGE         && irep2 == EDGE)         caseEE(edge1, edge2);
+  removeJunkNodes();
+
+}
+
+void BooleanProcessor::invertNewEdges(int iface)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::invertNewEdges            Date:    04.02.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Invert direction of new edges                             *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iedge = faces[iface].inew;
+  while (iedge > 0) {
+    edges[iedge].invert();
+    iedge = edges[iedge].inext;
+  }
+}
+
+void BooleanProcessor::checkDoubleEdges(int)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::checkDoubleEdges          Date:    04.02.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Eliminate duplication of edges                            *
+ *                                                                     *
+ ***********************************************************************/
+{
+
+}
+
+void BooleanProcessor::assembleFace(int what, int iface)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::assembleFace              Date:    19.02.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Assemble face                                             *
+ *                                                                     *
+ ***********************************************************************/
+{
+  //   A S S E M B L E   N E W   F A C E 
+
+  int ihead;      // head of the list of edges for new face
+  int icur;       // current edge in the list - last edge inserted to the list
+  int *ilink;     // pointer to the current link 
+  int ifirst;     // first node of a contour
+  int *i;         // pointer to the index of the current edge in a loop
+  int ioldflag=0; // is set if an edge from iold has been taken
+
+#define INSERT_EDGE_TO_THE_LIST(A) \
+*ilink = A; ilink = &edges[A].inext; *ilink = 0
+
+  ExtFace& face = faces[iface]; //G.Barrand : optimize.
+  ilink = &ihead;
+  for(;;) {
+    if (face.inew == 0) break;
+
+    //   S T A R T   N E W   C O N T O U R
+
+    icur   = face.inew;
+    face.inew = edges[icur].inext;
+    INSERT_EDGE_TO_THE_LIST(icur);
+    ifirst = edges[icur].i1; 
+    
+    //   C O N S T R U C T   T H E   C O N T O U R
+
+    for (;;) {
+      i = &face.inew;
+      ExtEdge& edge_cur = edges[icur];
+      while(*i > 0) {
+        ExtEdge& edge_i = edges[*i];
+        if (edge_i.i1 == edge_cur.i2) break;
+        i = &edge_i.inext;
+      }
+      if (*i == 0) {
+        i = &face.iold;   
+        while(*i > 0) {       
+          ExtEdge& edge_i = edges[*i];
+          if (edge_i.i1 == edge_cur.i2) {
+            ioldflag = 1;
+            break;
+          }
+          i = &edge_i.inext;
+        }
+      }
+      if (*i > 0) {
+        icur = *i;
+        *i = edges[icur].inext;
+        INSERT_EDGE_TO_THE_LIST(icur);
+        if (edges[icur].i2 == ifirst) { break; } else { continue; }
+      }else{
+        processor_error = 1;
+#ifdef BP_DEBUG
+        G4cerr
+          << "BooleanProcessor::assembleFace(" << iface << ") : "
+          << "could not find next edge of the contour"
+          << G4endl;
+#endif
+        face.inew = DEFECTIVE_FACE;
+        return;
+      }
+    }
+  }
+
+  //   C H E C K   O R I G I N A L   C O N T O U R
+
+  int iedge;
+  iedge = face.iold;
+  if (what == 0 && ioldflag == 0 && iedge > 0) {
+    for (;;) {
+      if (edges[iedge].inext > 0) {
+        if (edges[iedge].i2 == edges[edges[iedge].inext].i1) {
+          iedge = edges[iedge].inext;
+        }else{
+          break;
+        }
+      }else{
+        if (edges[iedge].i2 == edges[face.iold].i1) {
+          edges[iedge].inext = ihead;   // set new face
+          return;
+        }else{
+          break;
+        }
+      }
+    }
+  }
+
+  //   M A R K   U N S U I T A B L E   N E I G H B O U R I N G   F A C E S
+
+  int iface2;
+  iedge = face.iold;
+  while(iedge > 0) {
+    iface2 = edges[iedge].iface2;
+    if (faces[iface2].inew == 0) faces[iface2].inew = UNSUITABLE_FACE;
+    iedge = edges[iedge].inext;
+  }
+  face.iold = ihead;            // set new face
+}
+
+void BooleanProcessor::assembleNewFaces(int what, int ihead)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::assembleNewFaces          Date:    30.01.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Assemble internal or external parts of faces              *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iface = ihead;
+  while(iface > 0) {
+    if (faces[iface].inew > 0) {
+      if (what != 0) invertNewEdges(iface);
+      checkDoubleEdges(iface);
+      assembleFace(what, iface);
+      faces[iface].inew =
+        (faces[iface].iold == 0) ? UNSUITABLE_FACE : NEW_FACE;
+    }
+    iface = faces[iface].inext;
+  }
+}
+
+void BooleanProcessor::initiateLists()
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::initiateLists             Date:    28.02.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Initiate lists of faces.                                  *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int i, iface;
+
+  //   R E S E T   L I S T S   O F   F A C E S
+
+  result_faces.clean();
+  suitable_faces.clean();
+  unsuitable_faces.clean();
+  unknown_faces.clean();
+
+  //   I N I T I A T E   T H E   L I S T S
+
+  iface = iout1;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    if (operation == OP_INTERSECTION) {
+      unsuitable_faces.push_back(i);
+      faces[i].inew = UNSUITABLE_FACE;
+    }else{
+      suitable_faces.push_back(i);
+      faces[i].inew = ORIGINAL_FACE;
+    }
+  }
+  iface = iout2;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    if (operation == OP_UNION) {
+      suitable_faces.push_back(i);
+      faces[i].inew = ORIGINAL_FACE;
+    }else{
+      unsuitable_faces.push_back(i);
+      faces[i].inew = UNSUITABLE_FACE;
+    }
+  }
+
+  iface = iunk1;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    unknown_faces.push_back(i);
+  }
+  iface = iunk2;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    if (operation == OP_SUBTRACTION) faces[i].invert();
+    unknown_faces.push_back(i);
+  }
+
+  iface = ifaces1;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    switch(faces[i].inew) {
+    case UNKNOWN_FACE:
+      unknown_faces.push_back(i);
+      break;
+    case ORIGINAL_FACE: case NEW_FACE:
+      suitable_faces.push_back(i);
+      break;
+    case UNSUITABLE_FACE:
+      unsuitable_faces.push_back(i);
+      break;
+    default:
+      faces[i].iprev = 0;
+      faces[i].inext = 0;
+      break;
+    }
+  }
+  iface = ifaces2;
+  while (iface > 0) {
+    i     = iface;
+    iface = faces[i].inext;
+    if (operation == OP_SUBTRACTION) faces[i].invert();
+    switch(faces[i].inew) {
+    case UNKNOWN_FACE:
+      unknown_faces.push_back(i);
+      break;
+    case ORIGINAL_FACE: case NEW_FACE:
+      suitable_faces.push_back(i);
+      break;
+    case UNSUITABLE_FACE:
+      unsuitable_faces.push_back(i);
+      break;
+    default:
+      faces[i].iprev = 0;
+      faces[i].inext = 0;
+      break;
+    }
+  }
+  ifaces1 = ifaces2 = iout1 = iout2 = iunk1 = iunk2 = 0;
+}
+
+void BooleanProcessor::assemblePolyhedra()
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::assemblePolyhedra()       Date:    10.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Collect suitable faces and remove unsuitable ones.        *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int i, iedge, iface;
+
+  //   L O O P   A L O N G   S U I T A B L E   F A C E S
+
+  iface = suitable_faces.front();
+  while(iface > 0) {
+    i = iface;
+    iedge = faces[i].iold;
+    while(iedge > 0) {
+      iface = edges[iedge].iface2;
+      if (faces[iface].inew == UNKNOWN_FACE) {
+        unknown_faces.remove(iface);
+        suitable_faces.push_back(iface);
+        faces[iface].inew = ORIGINAL_FACE;
+      }
+      iedge = edges[iedge].inext;
+    }
+    iface = faces[i].inext;
+    suitable_faces.remove(i);
+    result_faces.push_back(i);
+  }
+  if (unknown_faces.front() == 0) return;
+
+  //   L O O P   A L O N G   U N S U I T A B L E   F A C E S
+
+  iface = unsuitable_faces.front();
+  while(iface > 0) {
+    i = iface;
+    iedge = faces[i].iold;
+    while(iedge > 0) {
+      iface = edges[iedge].iface2;
+      if (faces[iface].inew == UNKNOWN_FACE) {
+        unknown_faces.remove(iface);
+        unsuitable_faces.push_back(iface);
+        faces[iface].inew = UNSUITABLE_FACE;
+      }
+      iedge = edges[iedge].inext;
+    }
+    iface = faces[i].inext;
+    unsuitable_faces.remove(i);
+  }
+
+  //G.Barrand : begin
+  /* From S.Ponce
+   At last, there is a problem in the assemblePolyhedra method. At least, I
+  think it is there. The problem deals with boolean operations on solids,
+  when one of the two contains entirely the other one. It has no sense for
+  intersection and union but still has sense for subtraction. In this
+  case, faces from the inner solid are stored in the unknown_faces
+  FaceList. And an error occurs in the execute method. This may be correct
+  for intersection and union but in the case of subtraction, one should do
+  that in assemblePolyhedra :
+  */
+  //   Unknown faces are actually suitable face !!!
+   iface = unknown_faces.front();
+   while(iface > 0) {
+     i = iface;
+     faces[i].inew = ORIGINAL_FACE;
+     iface = faces[i].inext;
+     unknown_faces.remove(i);
+     result_faces.push_back(i);
+   }
+  /*
+   Otherwise, the inner hole that the second solid was building in the
+  first one does not exist. I'm not very clear on what to do for unions
+  and intersections. I think this kind of situation should be detected and
+  one of the solid should simply be ignored.
+  */
+  //G.Barrand : end
+}
+
+inline void
+BooleanProcessor::findABC(double x1, double y1, double x2, double y2,
+                          double &a, double &b, double &c) const
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::findABC                   Date:    07.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Find line equation Ax+By+C=0                              *
+ *                                                                     *
+ ***********************************************************************/
+{
+  double w;
+  a  = y1 - y2;
+  b  = x2 - x1;
+  //G.Barrand : w  = std::abs(a)+std::abs(b);
+  w  = ::fabs(a)+::fabs(b); //G.Barrand
+  a /= w;
+  b /= w;
+  c  = -(a*x2 + b*y2);
+}
+
+int BooleanProcessor::checkDirection(double *x, double *y) const
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::checkDirection            Date:    06.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Check direction of line 1-4                               *
+ *                                                                     *
+ ***********************************************************************/
+{
+  double a1, b1, c1, a2, b2, c2, d1, d2;
+
+  //   T E S T   L I N E   1 - 4   V S   E X T E R N A L   C O N T O U R
+
+  findABC(x[0], y[0], x[1], y[1], a1, b1, c1);
+  findABC(x[1], y[1], x[2], y[2], a2, b2, c2);
+  d1 = a1*x[4] + b1*y[4] + c1;
+  d2 = a2*x[4] + b2*y[4] + c2;
+  if (d1 <= del && d2 <= del)            return 1;
+  if (! (d1 > del && d2 > del)) {
+    if ( a1*x[2] + b1*y[2] + c1 >= -del) return 1;
+  }
+
+  //   T E S T   L I N E   1 - 4   V S   I N T E R N A L   C O N T O U R
+  
+  findABC(x[3], y[3], x[4], y[4], a1, b1, c1);
+  findABC(x[4], y[4], x[5], y[5], a2, b2, c2);
+  d1 = a1*x[1] + b1*y[1] + c1;
+  d2 = a2*x[1] + b2*y[1] + c2;
+  if (d1 <= del && d2 <= del)            return 1;
+  if (!(d1 > del && d2 > del)) {
+    if ( a1*x[5] + b1*y[5] + c1 >= -del) return 1;
+  }
+  return 0;
+}
+
+int BooleanProcessor::checkIntersection(int ix, int iy, int i1, int i2) const
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::checkDirection            Date:    06.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Check line i1-i2 on intersection with contours            *
+ *                                                                     *
+ ***********************************************************************/
+{
+  //  F I N D   L I N E   E Q U A T I O N
+
+  double x1, y1, x2, y2, a1, b1, c1;
+  x1 = nodes[i1].v[ix];
+  y1 = nodes[i1].v[iy];
+  x2 = nodes[i2].v[ix];
+  y2 = nodes[i2].v[iy];
+  findABC(x1, y1, x2, y2, a1, b1, c1);
+
+  //  L O O P   A L O N G   E X T E R N A L   C O N T O U R S
+
+  int icontour, iedge, k1, k2;
+  double x3, y3, x4, y4, a2, b2, c2, d1, d2;
+  for(icontour=0; icontour<(int)external_contours.size(); icontour++) {
+    iedge = external_contours[icontour];
+    while(iedge > 0) {
+      k1 = edges[iedge].i1;
+      k2 = edges[iedge].i2;
+      iedge = edges[iedge].inext;
+      if (k1 == i1 || k2 == i1) continue;
+      if (k1 == i2 || k2 == i2) continue;
+      x3 = nodes[k1].v[ix];
+      y3 = nodes[k1].v[iy];
+      x4 = nodes[k2].v[ix];
+      y4 = nodes[k2].v[iy];
+      d1 = a1*x3 + b1*y3 + c1;
+      d2 = a1*x4 + b1*y4 + c1;
+      if (d1 >  del && d2 >  del) continue;
+      if (d1 < -del && d2 < -del) continue;
+
+      findABC(x3, y3, x4, y4, a2, b2, c2);
+      d1 = a2*x1 + b2*y1 + c2;
+      d2 = a2*x2 + b2*y2 + c2;
+      if (d1 >  del && d2 >  del) continue;
+      if (d1 < -del && d2 < -del) continue;
+      return 1;
+    }
+  }
+
+  //  L O O P   A L O N G   E X T E R N A L   C O N T O U R S
+
+  for(icontour=0; icontour<(int)internal_contours.size(); icontour++) {
+    iedge = internal_contours[icontour];
+    while(iedge > 0) {
+      k1 = edges[iedge].i1;
+      k2 = edges[iedge].i2;
+      iedge = edges[iedge].inext;
+      if (k1 == i1 || k2 == i1) continue;
+      if (k1 == i2 || k2 == i2) continue;
+      x3 = nodes[k1].v[ix];
+      y3 = nodes[k1].v[iy];
+      x4 = nodes[k2].v[ix];
+      y4 = nodes[k2].v[iy];
+      d1 = a1*x3 + b1*y3 + c1;
+      d2 = a1*x4 + b1*y4 + c1;
+      if (d1 >  del && d2 >  del) continue;
+      if (d1 < -del && d2 < -del) continue;
+
+      findABC(x3, y3, x4, y4, a2, b2, c2);
+      d1 = a2*x1 + b2*y1 + c2;
+      d2 = a2*x2 + b2*y2 + c2;
+      if (d1 >  del && d2 >  del) continue;
+      if (d1 < -del && d2 < -del) continue;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void BooleanProcessor::mergeContours(int ix, int iy, int kext, int kint)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::mergeContours             Date:    06.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Attemp to merge internal contour with external one        *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int    i1ext, i2ext, i1int, i2int, i, k[6];
+  double x[6], y[6];
+
+  //   L O O P   A L O N G   E X T E R N A L   C O N T O U R
+
+  i1ext = external_contours[kext];
+  while (i1ext > 0) {
+    i2ext = edges[i1ext].inext;
+    if (i2ext == 0) i2ext = external_contours[kext];
+    k[0] = edges[i1ext].i1;
+    k[1] = edges[i1ext].i2;
+    k[2] = edges[i2ext].i2; 
+    for (i=0; i<3; i++) {
+      x[i] = nodes[k[i]].v[ix];
+      y[i] = nodes[k[i]].v[iy];
+    }
+
+    //   L O O P   A L O N G   I N T E R N A L   C O N T O U R
+
+    i1int = internal_contours[kint];
+    while (i1int > 0) {
+      i2int = edges[i1int].inext;
+      if (i2int == 0) i2int = internal_contours[kint];
+      k[3] = edges[i1int].i1;
+      k[4] = edges[i1int].i2;
+      k[5] = edges[i2int].i2; 
+      for (i=3; i<6; i++) {
+        x[i] = nodes[k[i]].v[ix];
+        y[i] = nodes[k[i]].v[iy];
+      }
+
+      //   T E S T   L I N E   K1 - K4
+      //   I F   O K   T H E N   M E R G E   C O N T O U R S
+
+      if (checkDirection(x, y) == 0) {
+        if (checkIntersection(ix, iy, k[1], k[4]) == 0) {
+          i = i1int;
+          for(;;) {
+            if (edges[i].inext == 0) {
+              edges[i].inext = internal_contours[kint];
+              internal_contours[kint] = 0;
+              break;
+            }else{
+              i = edges[i].inext;
+            }
+          }
+          i = edges[i1int].iface1;
+          edges.push_back(ExtEdge(k[1], k[4], i, -(int(edges.size())+1), -1));
+          edges.back().inext = i2int;
+          edges.push_back(ExtEdge(k[4], k[1], i, -(int(edges.size())-1), -1));
+          edges.back().inext = edges[i1ext].inext;
+          edges[i1ext].inext = edges.size()-2;
+          edges[i1int].inext = edges.size()-1;
+          return;
+        }
+      }
+      i1int = edges[i1int].inext;
+    }
+    i1ext = edges[i1ext].inext;
+  }
+}
+
+int
+BooleanProcessor::checkTriangle(int iedge1, int iedge2, int ix, int iy) const
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::checkTriangle             Date:    08.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Check triangle for correctness                            *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int    k[3];
+  double x[3], y[3];
+  double a1, b1, c1;
+
+  k[0] = edges[iedge1].i1;
+  k[1] = edges[iedge1].i2;
+  k[2] = edges[iedge2].i2;
+  for (int i=0; i<3; i++) {
+    x[i] = nodes[k[i]].v[ix];
+    y[i] = nodes[k[i]].v[iy];
+  }
+
+  //  C H E C K   P R I N C I P A L   C O R R E C T N E S S  
+    
+  findABC(x[2], y[2], x[0], y[0], a1, b1, c1);
+  if (a1*x[1]+b1*y[1]+c1 <= 0.1*del) return 1;
+
+  //   C H E C K   T H A T   T H E R E   I S   N O   P O I N T S   I N S I D E
+
+  int    inode, iedge;
+  double a2, b2, c2, a3, b3, c3;
+
+  findABC(x[0], y[0], x[1], y[1], a2, b2, c2);
+  findABC(x[1], y[1], x[2], y[2], a3, b3, c3);
+  iedge = iedge2;
+  for (;;) {
+    iedge = edges[iedge].inext;
+    if (edges[iedge].inext == iedge1) return 0;
+    inode = edges[iedge].i2;
+    if (inode == k[0])                continue;
+    if (inode == k[1])                continue;
+    if (inode == k[2])                continue;
+    x[1]  = nodes[inode].v[ix];
+    y[1]  = nodes[inode].v[iy];
+    if (a1*x[1]+b1*y[1]+c1 < -0.1*del)    continue;
+    if (a2*x[1]+b2*y[1]+c2 < -0.1*del)    continue;
+    if (a3*x[1]+b3*y[1]+c3 < -0.1*del)    continue;
+    return 1;
+  }
+}
+
+void BooleanProcessor::triangulateContour(int ix, int iy, int ihead)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::triangulateContour        Date:    06.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Triangulate external contour                              *
+ *                                                                     *
+ ***********************************************************************/
+{
+   
+  //G4cout << "Next Countour" << G4endl;
+  //int draw_flag = 0;
+  //if (draw_flag) draw_contour(5, 3, ihead);
+    
+  //   C L O S E   C O N T O U R
+  
+  int ipnext = ihead, nnode = 1;
+  for (;;) {
+    if (edges[ipnext].inext > 0) {
+      ipnext = edges[ipnext].inext;
+      nnode++; 
+    }else{
+      edges[ipnext].inext = ihead;
+      break;
+    }
+  }
+
+  //   L O O P   A L O N G   C O N T O U R  
+
+  //G4cerr << "debug : contour : begin : =================" << G4endl;
+  //dump();//debug
+
+  int iedge1, iedge2, iedge3, istart = 0;
+  for (;;) {
+    iedge1 = edges[ipnext].inext;
+    iedge2 = edges[iedge1].inext;
+/*
+    G4cerr << "debug :"
+              << " ipnext " << ipnext 
+              << " iedge1 " << iedge1 
+              << " iedge2 " << iedge2
+              << " : istart " << istart
+              << G4endl;
+*/
+    if (istart == 0) {
+      istart = iedge1;
+      if (nnode <= 3) {
+        iedge3 = edges[iedge2].inext;
+        edges[iedge1].iface1 = faces.size();
+        edges[iedge2].iface1 = faces.size();
+        edges[iedge3].iface1 = faces.size();
+        edges[iedge3].inext = 0;
+        faces.push_back(ExtFace(edges,0)); //G.Barrand : ok ?
+        faces.back().iold = iedge1;
+        faces.back().inew = ORIGINAL_FACE;
+
+  //if (draw_flag) draw_contour(4, 2, iedge1);
+
+        break;
+      }
+    }else if (istart == iedge1) {
+      processor_error = 1;
+#ifdef BP_DEBUG
+      G4cerr
+        << "BooleanProcessor::triangulateContour : "
+        << "could not generate a triangle (infinite loop)"
+        << G4endl;
+#endif
+      break;
+    }
+
+    //   C H E C K   C O R E C T N E S S   O F   T H E   T R I A N G L E
+
+    if (checkTriangle(iedge1,iedge2,ix,iy) != 0) {
+      ipnext  = edges[ipnext].inext;
+      continue; 
+    }
+
+    //   M O D I F Y   C O N T O U R  
+    
+    int i1 = edges[iedge1].i1;
+    int i3 = edges[iedge2].i2;
+    int iface1 = edges[iedge1].iface1;
+    int iface2 = faces.size();
+
+    edges[ipnext].inext = edges.size();
+    edges.push_back(ExtEdge(i1, i3, iface1, -(int(edges.size())+1), -1));
+    edges.back().inext = edges[iedge2].inext;
+
+    //   A D D   N E W   T R I A N G L E   T O   T H E   L I S T
+
+    edges[iedge2].inext = edges.size();
+    edges.push_back(ExtEdge(i3, i1, iface2, -(int(edges.size())-1), -1));
+    faces.push_back(ExtFace(edges,0)); //G.Barrand : ok ?
+    faces.back().iold   = iedge1;
+    faces.back().inew   = ORIGINAL_FACE;
+    edges[iedge1].iface1 = iface2;
+    edges[iedge2].iface1 = iface2;
+    ipnext  = edges[ipnext].inext;
+    istart = 0;
+    nnode--; 
+
+  //if (draw_flag)  draw_contour(4, 2, iedge1);
+
+  }
+}
+
+void BooleanProcessor::modifyReference(int iface, int i1, int i2, int iref)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::modifyReference           Date:    13.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Modify reference to the neighbouring face                 *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int iedge = faces[iface].iold;
+  while (iedge > 0) {
+    if (edges[iedge].i1 == i2 && edges[iedge].i2 == i1) {
+      edges[iedge].iface2 = iref;
+      return;
+    }
+    iedge = edges[iedge].inext;
+  }
+  processor_error = 1;
+#ifdef BP_DEBUG
+  G4cerr
+    << "BooleanProcessor::modifyReference : could not find the edge, "
+    << "iface=" << iface << ", i1,i2=" << i1 << "," << i2 << ", iref=" << iref
+    << G4endl;
+#endif
+}
+
+void BooleanProcessor::triangulateFace(int iface)
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::triangulateFace           Date:    02.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Triangulation of an extended face                         *
+ *                                                                     *
+ ***********************************************************************/
+{
+
+  //   F I N D   M A X   C O M P O N E N T   O F   T H E   N O R M A L
+  //   S E T  IX, IY, IZ
+
+#ifdef BP_GEANT4 //G.Barrand
+  HVNormal3D normal = faces[iface].plane.normal();
+#else
+  const HVNormal3D& normal = faces[iface].plane.getNormal();
+#endif
+  int ix, iy, iz = 0;
+  //G.Barrand : if (std::abs(normal[1]) > std::abs(normal[iz])) iz = 1;
+  //G.Barrand : if (std::abs(normal[2]) > std::abs(normal[iz])) iz = 2;
+  if (::fabs(normal[1]) > ::fabs(normal[iz])) iz = 1; //G.Barrand
+  if (::fabs(normal[2]) > ::fabs(normal[iz])) iz = 2; //G.Barrand
+  if (normal[iz] > 0) {
+    ix = (iz+1)%3; iy = (ix+1)%3;
+  }else{
+    iy = (iz+1)%3; ix = (iy+1)%3;
+  }
+
+  //   F I L L   L I S T S   O F   C O N T O U R S
+
+  external_contours.clear();
+  internal_contours.clear();
+  double z;
+  int    i1, i2, ifirst, iedge, icontour = faces[iface].iold;
+  while (icontour > 0) { 
+    iedge  = icontour;
+    ifirst = edges[iedge].i1;
+    z      = 0.0;
+    for(;;) {
+      if (iedge > 0) { 
+        i1 = edges[iedge].i1;
+        i2 = edges[iedge].i2;
+        ExtNode& node_1 = nodes[i1];
+        ExtNode& node_2 = nodes[i2];
+        z += node_1.v[ix]*node_2.v[iy]-node_2.v[ix]*node_1.v[iy];
+        if (ifirst != i2) {
+          iedge = edges[iedge].inext;
+          continue;
+        }else{
+          if (z > del*del) {
+            external_contours.push_back(icontour);
+          }else if (z < -del*del) {
+            internal_contours.push_back(icontour);
+          }else{  
+            processor_error = 1;
+#ifdef BP_DEBUG
+            G4cerr
+              << "BooleanProcessor::triangulateFace : too small contour"
+              << G4endl;
+#endif
+          }
+          icontour = edges[iedge].inext;
+          edges[iedge].inext = 0;
+          break;
+        }
+      }else{
+        processor_error = 1;
+#ifdef BP_DEBUG
+        G4cerr
+          << "BooleanProcessor::triangulateFace : broken contour"
+          << G4endl;
+#endif
+        icontour = 0;
+        break;
+      }
+    }
+  }
+
+  //   G E T   R I D   O F   I N T E R N A L   C O N T O U R S
+
+  int kint, kext;
+  for (kint=0; kint < (int)internal_contours.size(); kint++) {
+    for (kext=0; kext < (int)external_contours.size(); kext++) {
+      mergeContours(ix, iy, kext, kint); 
+      if (internal_contours[kint] == 0) break;
+    }
+    if (kext == (int)external_contours.size()) {
+      processor_error = 1;
+#ifdef BP_DEBUG
+      G4cerr
+        << "BooleanProcessor::triangulateFace : "
+        << "could not merge internal contour " << kint 
+        << G4endl;
+#endif
+    }      
+  }
+
+  //   T R I A N G U L A T E   C O N T O U R S
+
+  int nface = faces.size();
+  for (kext=0; kext < (int)external_contours.size(); kext++) {
+    triangulateContour(ix, iy, external_contours[kext]);
+#ifdef BP_DEBUG
+    if(processor_error) { //G.Barrand
+      G4cerr
+        << "BooleanProcessor::triangulateFace : "
+        << "triangulateContour failed."
+        << G4endl;
+      break; //G.Barrand : ok ?
+    }
+#endif      
+  }
+  faces[iface].inew = UNSUITABLE_FACE;
+
+  //   M O D I F Y   R E F E R E N C E S
+
+  for (int ifa=nface; ifa<(int)faces.size(); ifa++) {
+    iedge = faces[ifa].iold;
+    while (iedge > 0) {
+      if (edges[iedge].iface1 != ifa) {
+        processor_error = 1;
+#ifdef BP_DEBUG
+        G4cerr
+          << "BooleanProcessor::triangulateFace : wrong reference to itself, "
+          << "iface=" << ifa << ", iface1=" << edges[iedge].iface1
+          << G4endl;
+#endif
+      }else if (edges[iedge].iface2 > 0) {
+        modifyReference(edges[iedge].iface2,
+                        edges[iedge].i1, edges[iedge].i2, ifa);
+      }else if (edges[iedge].iface2 < 0) {
+        edges[iedge].iface2 = edges[-edges[iedge].iface2].iface1;
+      }
+      iedge = edges[iedge].inext;
+    }
+  }
+}
+
+HepPolyhedron BooleanProcessor::createPolyhedron()
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::createPolyhedron()        Date:    14.03.00 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Create HepPolyhedron.                                     *
+ *                                                                     *
+ ***********************************************************************/
+{
+  int i, iedge, nnode = 0, nface = 0;
+
+  //   R E N U M E R A T E   N O D E S   A N D   F A C E S
+
+  for (i=1; i<(int)nodes.size(); i++) nodes[i].s = 0;
+
+  for (i=1; i<(int)faces.size(); i++) {
+    if (faces[i].inew == ORIGINAL_FACE) {
+      faces[i].inew = ++nface;
+      iedge = faces[i].iold;
+      while (iedge > 0) {
+        nodes[edges[iedge].i1].s = 1;
+        iedge = edges[iedge].inext;
+      }
+    }else{
+      faces[i].inew = 0;
+    }
+  } 
+
+  for (i=1; i<(int)nodes.size(); i++) {
+    if (nodes[i].s == 1) nodes[i].s = ++nnode;
+  }
+
+  //   A L L O C A T E   M E M O R Y
+
+  ExtPolyhedron polyhedron;
+  if (nface == 0) return polyhedron;
+  polyhedron.AllocateMemory(nnode, nface);
+
+  //   S E T   N O D E S
+
+  for (i=1; i<(int)nodes.size(); i++) {
+    if (nodes[i].s != 0)  polyhedron.pV[nodes[i].s] = nodes[i].v;
+  }
+
+  //   S E T   F A C E S
+
+  int k = 0, v[4] = {0,0,0,0}, f[4] = {0,0,0,0};
+  for (i=1; i<(int)faces.size(); i++) {
+    if (faces[i].inew == 0) continue;
+    v[3] = f[3] = k = 0;
+    iedge = faces[i].iold;
+    while (iedge > 0) {
+      if (k > 3) {
+        G4cerr
+          << "BooleanProcessor::createPolyhedron : too many edges"
+          << G4endl;
+        break;
+      }
+      v[k]  = nodes[edges[iedge].i1].s;
+      if (edges[iedge].ivis < 0) v[k] = -v[k];
+      f[k]  = faces[edges[iedge].iface2].inew;
+      iedge = edges[iedge].inext;
+      k++;
+    }
+    if (k < 3) {
+      G4cerr
+        << "BooleanProcessor::createPolyhedron : "
+        << "face has only " << k << " edges"
+        << G4endl;
+    }
+    polyhedron.pF[faces[i].inew] =
+      G4Facet(v[0],f[0], v[1],f[1], v[2],f[2], v[3],f[3]); 
+  }
+  return polyhedron;
+}
+
+G4ThreadLocal int BooleanProcessor::ishift = 0; //G.Barrand
+int BooleanProcessor::get_shift() { return ishift;} //G.Barrand
+void BooleanProcessor::set_shift(int a_shift) { ishift = a_shift;} //G.Barrand
+#define NUM_SHIFT 8
+int BooleanProcessor::get_num_shift() { return NUM_SHIFT;} //G.Barrand
+
+HepPolyhedron BooleanProcessor::execute(int op,
+                                        const HepPolyhedron & a,
+                                        const HepPolyhedron & b,
+                                        int& err) //G.Barrand
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::execute                   Date:    10.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Execute boolean operation.                                *
+ *                                                                     *
+ ***********************************************************************/
+{
+  //static int ishift = 0; //G.Barrand
+  //static double shift[8][3] = {
+  static const double shift[NUM_SHIFT][3] = { //G.Barrand
+    {  31,  23,  17},
+    { -31, -23, -17},
+    { -23,  17,  31},
+    {  23, -17, -31},
+    { -17, -31,  23},
+    {  17,  31, -23},
+    {  31, -23,  17},
+    { -31,  23, -17}
+  };           
+
+/*
+  G4cerr << "BooleanProcessor::execute : ++++++++++++++++++++++"
+            << a.getName().getString()
+            << b.getName().getString()
+            << G4endl;
+*/
+
+  //   I N I T I A T E   P R O C E S S O R
+
+  processor_error = 0;
+  operation = op;
+  nodes.clear(); nodes.push_back(CRAZY_POINT);
+  edges.clear(); edges.push_back(ExtEdge());
+  faces.clear(); faces.push_back(ExtFace(edges,0)); //G.Barrand : ok ?
+
+  //   T A K E   P O L Y H E D R A
+
+  ifaces1 = faces.size(); takePolyhedron(a,0,0,0);
+  ifaces2 = faces.size(); takePolyhedron(b,0,0,0);
+
+  if (processor_error) {             // corrupted polyhedron
+    G4cerr
+      << "BooleanProcessor: corrupted input polyhedron"
+      << G4endl;
+    err = processor_error; //G.Barrand
+    return HepPolyhedron();
+  }
+  if (ifaces1 == ifaces2) {          // a is empty
+    err = processor_error; //G.Barrand
+    switch (operation) {
+    case OP_UNION:
+      return b;
+    case OP_INTERSECTION:
+      G4cerr 
+        << "BooleanProcessor: intersection with empty polyhedron"
+        << G4endl;
+      return HepPolyhedron();
+    case OP_SUBTRACTION:
+      G4cerr
+        << "BooleanProcessor: subtraction from empty polyhedron"
+        << G4endl;
+      return HepPolyhedron();
+    }
+  }
+  if (ifaces2 == (int)faces.size()) {     // b is empty
+    err = processor_error; //G.Barrand
+    switch (operation) {
+    case OP_UNION:
+      return a;
+    case OP_INTERSECTION:
+      G4cerr
+        << "BooleanProcessor: intersection with empty polyhedron"
+        << G4endl;
+      return HepPolyhedron();
+    case OP_SUBTRACTION:
+      return a;
+    }
+  }
+
+  //   S E T   I N I T I A L   M I N - M A X   A N D   T O L E R A N C E
+
+  del = findMinMax();
+
+  //   W O R K A R O U N D   T O   A V O I D   I E   A N D   E E
+          
+/*
+#define PROCESSOR_ERROR(a_what) \
+  G4cerr << "BooleanProcessor: boolean operation problem (" << a_what \
+            << "). Try again with other shifts."\
+            << G4endl;
+*/
+#define PROCESSOR_ERROR(a_what)
+
+  unsigned int try_count = 1;
+  while(true) { //G.Barrand
+
+  double ddxx = del*shift[ishift][0];
+  double ddyy = del*shift[ishift][1];
+  double ddzz = del*shift[ishift][2];
+  ishift++; if (ishift == get_num_shift()) ishift = 0;
+
+  processor_error = 0; //G.Barrand
+  operation = op;
+  nodes.clear(); nodes.push_back(CRAZY_POINT);
+  edges.clear(); edges.push_back(ExtEdge());
+  faces.clear(); faces.push_back(ExtFace(edges,0)); //G.Barrand : ok ?
+
+  ifaces1 = faces.size(); takePolyhedron(a,0,0,0);
+  ifaces2 = faces.size(); takePolyhedron(b,ddxx,ddyy,ddzz);
+
+  if (processor_error) { PROCESSOR_ERROR(1) } //G.Barrand
+
+  del = findMinMax();
+
+  //   P R E S E L E C T   O U T S I D E   F A C E S
+
+  iout1 = iout2 = 0;
+  selectOutsideFaces(ifaces1, iout1);
+  selectOutsideFaces(ifaces2, iout2);
+
+  if (processor_error) { PROCESSOR_ERROR(2) } //G.Barrand
+
+  //   P R E S E L E C T   N O   I N T E R S E C T I O N   F A C E S
+
+  int ifa1, ifa2;
+  iunk1 = iunk2 = 0;
+  if (iout1 != 0 || iout2 != 0) {
+    for(;;) {
+      ifa1 = iunk1;
+      ifa2 = iunk2;
+      selectOutsideFaces(ifaces1, iunk1);
+      selectOutsideFaces(ifaces2, iunk2);
+      if (iunk1 == ifa1 && iunk2 == ifa2) break;
+      findMinMax();
+    }
+  }
+
+  if (processor_error) { PROCESSOR_ERROR(3) } //G.Barrand
+
+  //   F I N D   N E W   E D G E S
+
+  if (ifaces1 != 0 && ifaces2 != 0 ) {
+    ifa1 = ifaces1;
+    while (ifa1 > 0) {
+      ifa2 = ifaces2;
+      while (ifa2 > 0) {
+        testFaceVsFace(ifa1, ifa2);
+        ifa2 = faces[ifa2].inext;
+      }
+      ifa1 = faces[ifa1].inext;
+    }
+  }
+  if (processor_error) { PROCESSOR_ERROR(4) } //G.Barrand
+
+  //   C O N S T R U C T   N E W   F A C E S
+
+  assembleNewFaces((operation == OP_INTERSECTION) ? 1 : 0, ifaces1);
+  if (processor_error) { PROCESSOR_ERROR(5) } //G.Barrand
+  assembleNewFaces((operation == OP_UNION) ? 0 : 1, ifaces2);
+  if (processor_error) { PROCESSOR_ERROR(6) } //G.Barrand
+
+  //   A S S E M B L E   S U I T A B L E   F A C E S
+
+  initiateLists();
+  assemblePolyhedra();
+  if (unknown_faces.front() != 0) {
+    processor_error = 1;
+#ifdef BP_DEBUG
+    G4cerr
+      << "BooleanProcessor::execute : unknown faces !!!"
+      << G4endl;
+#endif
+  }
+  if (processor_error) { PROCESSOR_ERROR(7) } //G.Barrand
+
+  //   T R I A N G U L A T E   A C C E P T E D   F A C E S 
+
+  ifa1 = result_faces.front();
+  while (ifa1 > 0) {
+    ifa2 = ifa1;
+    ifa1 = faces[ifa2].inext;
+    if (faces[ifa2].inew == NEW_FACE) triangulateFace(ifa2);
+    if (processor_error) { 
+      PROCESSOR_ERROR(8) //G.Barrand
+      break; //G.Barrand
+    }
+  }
+
+  if(!processor_error) {   
+#ifdef BP_DEBUG
+    if(try_count!=1) {
+      G4cerr
+         << "BooleanProcessor::execute : had converged."
+         << G4endl;
+    }
+#endif
+    break;
+  }
+
+  if((int)try_count>get_num_shift()) {
+#ifdef BP_DEBUG
+    /*** Commented out because HepPolyhedron does not have getName...?!
+    G4cerr << "BooleanProcessor: "
+              << " all shifts tried. Boolean operation (" << op << ") failure."
+              << " a name \"" << a.getName().getString() << "\""
+              << " b name \"" << b.getName().getString() << "\""
+              << G4endl;
+    ***/
+#endif
+    err = processor_error;
+    return a;
+  }
+
+#ifdef BP_DEBUG
+  G4cerr
+     << "BooleanProcessor::execute : try another tilt..."
+     << G4endl;
+#endif
+
+  try_count++;
+
+  } //G.Barrand : end while shift.
+#undef PROCESSOR_ERROR //G.Barrand
+
+  //   C R E A T E   P O L Y H E D R O N
+  
+  err = processor_error;
+  return createPolyhedron();
+}
+
+
+//#include <cfortran.h>
+//#include <higz.h>
+//#include "zbuf.h"
+//void BooleanProcessor::draw()
+/***********************************************************************
+ *                                                                     *
+ * Name: BooleanProcessor::draw                      Date:    10.12.99 *
+ * Author: E.Chernyaev                               Revised:          *
+ *                                                                     *
+ * Function: Draw                                                      *
+ *                                                                     *
+ ***********************************************************************/
+/*
+{
+  int II;
+  int   icol, i1, i2, iedge, iface, ilist[4];
+  float p1[3], p2[3];
+
+  ilist[0] = ifaces1;
+  ilist[1] = ifaces2;
+  ilist[2] = iout1;
+  ilist[3] = iout2;
+
+  for (int i=0; i<4; i++) { 
+
+    if (i == 0) G4cout << "========= Ifaces_1" << G4endl;
+    if (i == 1) G4cout << "========= Ifaces_2" << G4endl;
+    if (i == 2) G4cout << "========= Iout_1" << G4endl;
+    if (i == 3) G4cout << "========= Iout_2" << G4endl;
+
+    icol = i+1;
+    iface = ilist[i];
+    while (iface > 0) {
+
+      G4cout << "iface = " << iface << G4endl;
+      G4cout << "--- iold" << G4endl;
+
+      iedge = faces[iface].iold;
+      icol = 2;
+
+      while (iedge > 0) {
+
+        G4cout << "  iegde = " << iedge
+             << " i1,i2 =" << edges[iedge].i1 << "," << edges[iedge].i2
+             << " iface1,iface2 = "
+             << edges[iedge].iface1 << "," << edges[iedge].iface2
+             << G4endl;
+
+        i1 = edges[iedge].i1;
+        p1[0] = nodes[i1].v.x();
+        p1[1] = nodes[i1].v.y();
+        p1[2] = nodes[i1].v.z();
+        IHWTON(p1,p1);
+        i2 = edges[iedge].i2;
+        p2[0] = nodes[i2].v.x();
+        p2[1] = nodes[i2].v.y();
+        p2[2] = nodes[i2].v.z();
+        IHWTON(p2,p2);
+//        icol =  (edges[iedge].ivis > 0) ? 1 : 2;
+        IHZLIN(icol,p1[0],p1[1],p1[2], p2[0],p2[1],p2[2]);
+        iedge = edges[iedge].inext;
+      }
+      
+      G4cout << "--- inew" << G4endl;
+
+      iedge = faces[iface].inew;
+      icol = 3;
+
+      while (iedge > 0) {
+
+        G4cout << "  iegde = " << iedge
+             << " i1,i2 =" << edges[iedge].i1 << "," << edges[iedge].i2
+             << " iface1,iface2 = "
+             << edges[iedge].iface1 << "," << edges[iedge].iface2
+             << G4endl;
+
+        i1 = edges[iedge].i1;
+        p1[0] = nodes[i1].v.x();
+        p1[1] = nodes[i1].v.y();
+        p1[2] = nodes[i1].v.z();
+        IHWTON(p1,p1);
+        i2 = edges[iedge].i2;
+        p2[0] = nodes[i2].v.x();
+        p2[1] = nodes[i2].v.y();
+        p2[2] = nodes[i2].v.z();
+        IHWTON(p2,p2);
+//        icol =  (edges[iedge].ivis > 0) ? 1 : 2;
+        IHZLIN(icol,p1[0],p1[1],p1[2], p2[0],p2[1],p2[2]);
+        iedge = edges[iedge].inext;
+      }
+      iface = faces[iface].inext;
+
+      IHZTOX(0,100,100);
+      ixupdwi(0);
+      cin >> II;
+      ixclrwi();
+      IHZCLE(0);
+    }
+  }
+}
+*/
+
+/*
+//--------------------------------------------------------------------
+void
+BooleanProcessor::draw_edge(int icol, int iedge) {
+  int   i1, i2;
+  float p1[3], p2[3];
+
+  i1 = edges[iedge].i1;
+  p1[0] = nodes[i1].v.x();
+  p1[1] = nodes[i1].v.y();
+  p1[2] = nodes[i1].v.z();
+  IHWTON(p1,p1);
+  i2 = edges[iedge].i2;
+  p2[0] = nodes[i2].v.x();
+  p2[1] = nodes[i2].v.y();
+  p2[2] = nodes[i2].v.z();
+  IHWTON(p2,p2);
+  IHZLIN(icol,p1[0],p1[1],p1[2], p2[0],p2[1],p2[2]);
+}
+
+//--------------------------------------------------------------------
+void
+BooleanProcessor::draw_contour(int i1col, int i2col, int ihead) {
+  int iedge, icol;
+  iedge = ihead;
+  while (iedge > 0) {
+    icol = (edges[iedge].ivis > 0) ? i1col : i2col;
+    draw_edge(icol, iedge);
+    iedge = edges[iedge].inext;
+  }
+
+  IHZTOX(0,100,100);
+  ixupdwi(0);
+
+  int i; 
+  std::cin >> i; 
+}
+
+//--------------------------------------------------------------------
+void
+BooleanProcessor::print_face(int iface) {
+  G4cout.precision(3);
+  G4cout << "\n====== Face N " << iface << G4endl;
+  G4cout << "iedges[4] = "
+       << faces[iface].iedges[0] << ", "
+       << faces[iface].iedges[1] << ", "
+       << faces[iface].iedges[2] << ", "
+       << faces[iface].iedges[3] << G4endl;
+  G4cout << "rmin[3] = "
+       << faces[iface].rmin[0] << ", "
+       << faces[iface].rmin[1] << ", "
+       << faces[iface].rmin[2] << G4endl;
+  G4cout << "rmax[3] = "
+       << faces[iface].rmax[0] << ", "
+       << faces[iface].rmax[1] << ", "
+       << faces[iface].rmax[2] << G4endl;
+  G4cout << "iprev,inext = "
+       << faces[iface].iprev << ", "
+       << faces[iface].inext << G4endl;
+  G4cout << "iold = " << faces[iface].iold << G4endl;
+  for(int i = faces[iface].iold; i != 0;) {
+    print_edge(i);
+    i = edges[abs(i)].inext;
+  }
+
+  G4cout << "inew = ";
+  switch (faces[iface].inew) {
+  case UNKNOWN_FACE:
+    G4cout << "UNKNOWN_FACE" << G4endl;
+    break;
+  case ORIGINAL_FACE:
+    G4cout << "ORIGINAL_FACE" << G4endl;
+    break;
+  case NEW_FACE:
+    G4cout << "NEW_FACE" << G4endl;
+    break;
+  case UNSUITABLE_FACE:
+    G4cout << "UNSUITABLE_FACE" << G4endl;
+    break;
+  case DEFECTIVE_FACE:
+    G4cout << "DEFECTIVE_FACE" << G4endl;
+    break;
+  default:
+    G4cout << faces[iface].inew << G4endl;
+    for(int k = faces[iface].inew; k != 0;) {
+      print_edge(k);
+      k = edges[abs(k)].inext;
+    }
+  }
+}
+
+//--------------------------------------------------------------------
+void
+BooleanProcessor::print_edge(int iedge) {
+  G4cout << "==== Edge N " << iedge << G4endl;
+  int i = std::abs(iedge);
+  int i1 = edges[i].i1;
+  int i2 = edges[i].i2;
+  G4cout << "node[" << i1 << "] = " 
+       << nodes[i1].v.x() << ", "
+       << nodes[i1].v.y() << ", "
+       << nodes[i1].v.z() << G4endl;
+
+  G4cout << "node[" << i2 << "] = " 
+       << nodes[i2].v.x() << ", "
+       << nodes[i2].v.y() << ", "
+       << nodes[i2].v.z() << G4endl;
+
+  G4cout << "iface1,iface2,ivis,inext = "
+       << edges[i].iface1 << ", "
+       << edges[i].iface2 << ", "
+       << edges[i].ivis   << ", "
+       << edges[i].inext  << G4endl;
+}
+*/
+
+void BooleanProcessor::dump() {//G.Barrand
+  unsigned int number = nodes.size();
+  G4cout << "nodes : " << number << G4endl;
+  for(unsigned int index=0;index<number;index++) { 
+    const ExtNode& node = nodes[index];
+    G4cout << " " << index
+           << " x = " << node.v[0]
+           << " y = " << node.v[1]
+           << " z = " << node.v[2]
+           << G4endl;
+  }
+}

--- a/src/G4.10.03.p01fixes/G4IntersectingCone.cc
+++ b/src/G4.10.03.p01fixes/G4IntersectingCone.cc
@@ -1,0 +1,382 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4IntersectingCone.cc 95997 2016-03-07 13:16:25Z gcosmo $
+//
+// 
+// --------------------------------------------------------------------
+// GEANT 4 class source file
+//
+//
+// G4IntersectingCone.cc
+//
+// Implementation of a utility class which calculates the intersection
+// of an arbitrary line with a fixed cone
+// --------------------------------------------------------------------
+
+#include "G4IntersectingCone.hh"
+#include "G4GeometryTolerance.hh"
+
+//
+// Constructor
+//
+G4IntersectingCone::G4IntersectingCone( const G4double r[2],
+                                        const G4double z[2] )
+{ 
+  const G4double halfCarTolerance
+    = 0.5 * G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
+
+  //
+  // What type of cone are we?
+  //
+  type1 = (std::fabs(z[1]-z[0]) > std::fabs(r[1]-r[0]));
+  
+  if (type1)
+  {
+    B = (r[1]-r[0])/(z[1]-z[0]);      // tube like
+    A = 0.5*( r[1]+r[0] - B*(z[1]+z[0]) );
+  }
+  else
+  {
+    B = (z[1]-z[0])/(r[1]-r[0]);      // disk like
+    A = 0.5*( z[1]+z[0] - B*(r[1]+r[0]) );
+  }
+  //
+  // Calculate extent
+  //
+  if (r[0] < r[1])
+  {
+    rLo = r[0]-halfCarTolerance; rHi = r[1]+halfCarTolerance;
+  }
+  else
+  {
+    rLo = r[1]-halfCarTolerance; rHi = r[0]+halfCarTolerance;
+  }
+  
+  if (z[0] < z[1])
+  {
+    zLo = z[0]-halfCarTolerance; zHi = z[1]+halfCarTolerance;
+  }
+  else
+  {
+    zLo = z[1]-halfCarTolerance; zHi = z[0]+halfCarTolerance;
+  }
+}
+
+
+//
+// Fake default constructor - sets only member data and allocates memory
+//                            for usage restricted to object persistency.
+//
+G4IntersectingCone::G4IntersectingCone( __void__& )
+  : zLo(0.), zHi(0.), rLo(0.), rHi(0.), type1(false), A(0.), B(0.)
+{
+}
+
+
+//
+// Destructor
+//
+G4IntersectingCone::~G4IntersectingCone()
+{
+}
+
+
+//
+// HitOn
+//
+// Check r or z extent, as appropriate, to see if the point is possibly
+// on the cone.
+//
+G4bool G4IntersectingCone::HitOn( const G4double r,
+                                  const G4double z )
+{
+  //
+  // Be careful! The inequalities cannot be "<=" and ">=" here without
+  // punching a tiny hole in our shape!
+  //
+  if (type1)
+  {
+    if (z < zLo || z > zHi) return false;
+  }
+  else
+  {
+    if (r < rLo || r > rHi) return false;
+  }
+
+  return true;
+}
+
+
+//
+// LineHitsCone
+//
+// Calculate the intersection of a line with our conical surface, ignoring
+// any phi division
+//
+G4int G4IntersectingCone::LineHitsCone( const G4ThreeVector &p,
+                                        const G4ThreeVector &v,
+                                              G4double *s1, G4double *s2 )
+{
+  if (type1)
+  {
+    return LineHitsCone1( p, v, s1, s2 );
+  }
+  else
+  {
+    return LineHitsCone2( p, v, s1, s2 );
+  }
+}
+
+
+//
+// LineHitsCone1
+//
+// Calculate the intersections of a line with a conical surface. Only
+// suitable if zPlane[0] != zPlane[1].
+//
+// Equation of a line:
+//
+//       x = x0 + s*tx      y = y0 + s*ty      z = z0 + s*tz
+//
+// Equation of a conical surface:
+//
+//       x**2 + y**2 = (A + B*z)**2
+//
+// Solution is quadratic:
+//
+//  a*s**2 + b*s + c = 0
+//
+// where:
+//
+//  a = x0**2 + y0**2 - (A + B*z0)**2
+//
+//  b = 2*( x0*tx + y0*ty - (A*B - B*B*z0)*tz)
+//
+//  c = tx**2 + ty**2 - (B*tz)**2
+//
+// Notice, that if a < 0, this indicates that the two solutions (assuming
+// they exist) are in opposite cones (that is, given z0 = -A/B, one z < z0
+// and the other z > z0). For our shapes, the invalid solution is one
+// which produces A + Bz < 0, or the one where Bz is smallest (most negative).
+// Since Bz = B*s*tz, if B*tz > 0, we want the largest s, otherwise,
+// the smaller.
+//
+// If there are two solutions on one side of the cone, we want to make
+// sure that they are on the "correct" side, that is A + B*z0 + s*B*tz >= 0.
+//
+// If a = 0, we have a linear problem: s = c/b, which again gives one solution.
+// This should be rare.
+//
+// For b*b - 4*a*c = 0, we also have one solution, which is almost always
+// a line just grazing the surface of a the cone, which we want to ignore. 
+// However, there are two other, very rare, possibilities:
+// a line intersecting the z axis and either:
+//       1. At the same angle std::atan(B) to just miss one side of the cone, or
+//       2. Intersecting the cone apex (0,0,-A/B)
+// We *don't* want to miss these! How do we identify them? Well, since
+// this case is rare, we can at least swallow a little more CPU than we would
+// normally be comfortable with. Intersection with the z axis means
+// x0*ty - y0*tx = 0. Case (1) means a==0, and we've already dealt with that
+// above. Case (2) means a < 0.
+//
+// Now: x0*tx + y0*ty = 0 in terms of roundoff error. We can write:
+//             Delta = x0*tx + y0*ty
+//             b = 2*( Delta - (A*B + B*B*z0)*tz )
+// For:
+//             b*b - 4*a*c = epsilon
+// where epsilon is small, then:
+//             Delta = epsilon/2/B
+// 
+G4int G4IntersectingCone::LineHitsCone1( const G4ThreeVector &p,
+                                         const G4ThreeVector &v,
+                                               G4double *s1, G4double *s2 )
+{
+  static const G4double EPS = DBL_EPSILON; // Precision constant,
+                                           // originally it was 1E-6
+  G4double x0 = p.x(), y0 = p.y(), z0 = p.z();
+  G4double tx = v.x(), ty = v.y(), tz = v.z();
+
+  G4double a = tx*tx + ty*ty - sqr(B*tz);
+  G4double b = 2*( x0*tx + y0*ty - (A*B + B*B*z0)*tz);
+  G4double c = x0*x0 + y0*y0 - sqr(A + B*z0);
+  
+  G4double radical = b*b - 4*a*c;
+ 
+  if (radical < -EPS*EPS*b*b)  { return 0; }    // No solution
+  
+  if (radical < EPS*EPS*b*b)
+  {
+    //
+    // The radical is roughly zero: check for special, very rare, cases
+    //
+    if (std::fabs(a) > 1/kInfinity)
+      {
+      if(B==0.) { return 0; }
+      if ( std::fabs(x0*ty - y0*tx) < std::fabs(EPS/(B+1e-99)) )
+      {
+         *s1 = -0.5*b/a;
+         return 1;
+      }
+      return 0;
+    }
+  }
+  else
+  {
+    radical = std::sqrt(radical);
+  }
+  
+  if (a > 1/kInfinity)
+  {
+    G4double sa, sb, q = -0.5*( b + (b < 0 ? -radical : +radical) );
+    sa = q/a;
+    sb = c/q;
+    if (sa < sb) { *s1 = sa; *s2 = sb; } else { *s1 = sb; *s2 = sa; }
+    if (A + B*(z0+(*s1)*tz) < 0)  { return 0; }
+    return 2;
+  }
+  else if (a < -1/kInfinity)
+  {
+    G4double sa, sb, q = -0.5*( b + (b < 0 ? -radical : +radical) );
+    sa = q/a;
+    sb = c/q;
+    *s1 = (B*tz > 0)^(sa > sb) ? sb : sa;
+    return 1;
+  }
+  else if (std::fabs(b) < 1/kInfinity)
+  {
+    return 0;
+  }
+  else
+  {
+    *s1 = -c/b;
+    if (A + B*(z0+(*s1)*tz) < 0)  { return 0; }
+    return 1;
+  }
+}
+
+  
+//
+// LineHitsCone2
+//
+// See comments under LineHitsCone1. In this routine, case2, we have:
+//
+//   Z = A + B*R
+//
+// The solution is still quadratic:
+//
+//  a = tz**2 - B*B*(tx**2 + ty**2)
+//
+//  b = 2*( (z0-A)*tz - B*B*(x0*tx+y0*ty) )
+//
+//  c = ( (z0-A)**2 - B*B*(x0**2 + y0**2) )
+//
+// The rest is much the same, except some details.
+//
+// a > 0 now means we intersect only once in the correct hemisphere.
+//
+// a > 0 ? We only want solution which produces R > 0. 
+// since R = (z0+s*tz-A)/B, for tz/B > 0, this is the largest s
+//          for tz/B < 0, this is the smallest s
+// thus, same as in case 1 ( since sign(tz/B) = sign(tz*B) )
+//
+G4int G4IntersectingCone::LineHitsCone2( const G4ThreeVector &p,
+                                         const G4ThreeVector &v,
+                                               G4double *s1, G4double *s2 )
+{
+  static const G4double EPS = DBL_EPSILON; // Precision constant,
+                                           // originally it was 1E-6
+  G4double x0 = p.x(), y0 = p.y(), z0 = p.z();
+  G4double tx = v.x(), ty = v.y(), tz = v.z();
+  
+  // Special case which might not be so rare: B = 0 (precisely)
+  //
+  if (B==0)
+  {
+    if (std::fabs(tz) < 1/kInfinity)  { return 0; }
+    
+    *s1 = (A-z0)/tz;
+    return 1;
+  }
+
+  G4double B2 = B*B;
+
+  G4double a = tz*tz - B2*(tx*tx + ty*ty);
+  G4double b = 2*( (z0-A)*tz - B2*(x0*tx + y0*ty) );
+  G4double c = sqr(z0-A) - B2*( x0*x0 + y0*y0 );
+  
+  G4double radical = b*b - 4*a*c;
+ 
+  if (radical < -EPS*EPS*b*b) { return 0; }   // No solution
+  
+  if (radical < EPS*EPS*b*b)
+  {
+    //
+    // The radical is roughly zero: check for special, very rare, cases
+    //
+    if (std::fabs(a) > 1/kInfinity)
+    {
+      if ( std::fabs(x0*ty - y0*tx) < std::fabs(EPS/(B+1e-99)) )
+      {
+        *s1 = -0.5*b/a;
+        return 1;
+      }
+      return 0;
+    }
+  }
+  else
+  {
+    radical = std::sqrt(radical);
+  }
+  
+  if (a < -1/kInfinity)
+  {
+    G4double sa, sb, q = -0.5*( b + (b < 0 ? -radical : +radical) );
+    sa = q/a;
+    sb = c/q;
+    if (sa < sb) { *s1 = sa; *s2 = sb; } else { *s1 = sb; *s2 = sa; }
+    if ((z0 + (*s1)*tz  - A)/B < 0)  { return 0; }
+    return 2;
+  }
+  else if (a > 1/kInfinity)
+  {
+    G4double sa, sb, q = -0.5*( b + (b < 0 ? -radical : +radical) );
+    sa = q/a;
+    sb = c/q;
+    *s1 = (tz*B > 0)^(sa > sb) ? sb : sa;
+    return 1;
+  }
+  else if (std::fabs(b) < 1/kInfinity)
+  {
+    return 0;
+  }
+  else
+  {
+    *s1 = -c/b;
+    if ((z0 + (*s1)*tz  - A)/B < 0)  { return 0; }
+    return 1;
+  }
+}

--- a/src/G4.10.03.p01fixes/G4MTHepRandom.cc
+++ b/src/G4.10.03.p01fixes/G4MTHepRandom.cc
@@ -1,0 +1,33 @@
+
+// 4/9/2017  D. Lawrence
+// When trying to run on OS X 10.11 I got a run time link error
+// for G4MTHepRandom::getTheTableSeeds(long*, int). The routine
+// CLHEP::HepRandom::getTheTableSeeds(long*, int) was defined in
+// the G4 libraries. Unfortunately, it seems the G4MTHepRandom
+// only has a pointer to a HepRandomEngine which does not have
+// this method.
+//
+// Looking at G4MTHepRandom in the G4 source, it oddly declares
+// this in the header file, but does not define it in the .cc
+// file along with all of the other static methods (???).
+//
+// This just defines the static method modeled after the other
+// static methods in G4MTHepRandom
+
+#include <stdlib.h>
+#include <iostream>
+using namespace std;
+
+#include <G4MTHepRandom.hh>
+#include <CLHEP/Random/Random.h>
+
+#ifdef __APPLE__
+
+void G4MTHepRandom::getTheTableSeeds (G4long* seeds, G4int index)
+{
+	static CLHEP::HepRandom *hr = NULL;
+	if(!hr) hr = new CLHEP::HepRandom(getTheEngine());
+	hr->getTheTableSeeds(seeds, index);
+}
+
+#endif // __APPLE__

--- a/src/G4.10.03.p01fixes/G4OpenGLStoredSceneHandler.cc
+++ b/src/G4.10.03.p01fixes/G4OpenGLStoredSceneHandler.cc
@@ -1,0 +1,639 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4OpenGLStoredSceneHandler.cc 99312 2016-09-13 09:47:18Z gcosmo $
+//
+// 
+// Andrew Walkden  10th February 1997
+// OpenGL stored scene - creates OpenGL display lists.
+
+#ifdef G4VIS_BUILD_OPENGL_DRIVER
+
+#include "G4OpenGLStoredSceneHandler.hh"
+
+#include "G4PhysicalVolumeModel.hh"
+#include "G4LogicalVolumeModel.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Polyline.hh"
+#include "G4Polymarker.hh"
+#include "G4Text.hh"
+#include "G4Circle.hh"
+#include "G4Square.hh"
+#include "G4Polyhedron.hh"
+#include "G4AttHolder.hh"
+#include "G4OpenGLTransform3D.hh"
+#include "G4OpenGLViewer.hh"
+#include "G4AttHolder.hh"
+
+#include <typeinfo>
+
+G4int G4OpenGLStoredSceneHandler::fSceneIdCount = 0;
+
+G4int  G4OpenGLStoredSceneHandler::fDisplayListId = 0;
+G4bool G4OpenGLStoredSceneHandler::fMemoryForDisplayLists = true;
+G4int  G4OpenGLStoredSceneHandler::fDisplayListLimit = 50000;
+
+G4OpenGLStoredSceneHandler::PO::PO():
+  fDisplayListId(0),
+  fPickName(0),
+  fpG4TextPlus(0),
+  fMarkerOrPolyline(false)
+{}
+
+G4OpenGLStoredSceneHandler::PO::PO(const G4OpenGLStoredSceneHandler::PO& po):
+  fDisplayListId(po.fDisplayListId),
+  fTransform(po.fTransform),
+  fPickName(po.fPickName),
+  fColour(po.fColour),
+  fpG4TextPlus(po.fpG4TextPlus? new G4TextPlus(*po.fpG4TextPlus): 0),
+  fMarkerOrPolyline(po.fMarkerOrPolyline)
+{}
+
+G4OpenGLStoredSceneHandler::PO::PO(G4int id, const G4Transform3D& tr):
+  fDisplayListId(id),
+  fTransform(tr),
+  fPickName(0),
+  fpG4TextPlus(0),
+  fMarkerOrPolyline(false)
+{}
+
+G4OpenGLStoredSceneHandler::PO::~PO()
+{
+  delete fpG4TextPlus;
+}
+
+G4OpenGLStoredSceneHandler::PO& G4OpenGLStoredSceneHandler::PO::operator=
+  (const G4OpenGLStoredSceneHandler::PO& rhs)
+{
+  if (&rhs == this) return *this;
+  fDisplayListId = rhs.fDisplayListId;
+  fTransform = rhs.fTransform;
+  fPickName = rhs.fPickName;
+  fColour = rhs.fColour;
+  fpG4TextPlus = rhs.fpG4TextPlus? new G4TextPlus(*rhs.fpG4TextPlus): 0;
+  fMarkerOrPolyline = rhs.fMarkerOrPolyline;
+  return *this;
+}
+
+G4OpenGLStoredSceneHandler::TO::TO():
+  fDisplayListId(0),
+  fPickName(0),
+  fStartTime(-DBL_MAX),
+  fEndTime(DBL_MAX),
+  fpG4TextPlus(0),
+  fMarkerOrPolyline(false)
+{}
+
+G4OpenGLStoredSceneHandler::TO::TO(const G4OpenGLStoredSceneHandler::TO& to):
+  fDisplayListId(to.fDisplayListId),
+  fTransform(to.fTransform),
+  fPickName(to.fPickName),
+  fStartTime(to.fStartTime),
+  fEndTime(to.fEndTime),
+  fColour(to.fColour),
+  fpG4TextPlus(to.fpG4TextPlus? new G4TextPlus(*to.fpG4TextPlus): 0),
+  fMarkerOrPolyline(to.fMarkerOrPolyline)
+{}
+
+G4OpenGLStoredSceneHandler::TO::TO(G4int id, const G4Transform3D& tr):
+  fDisplayListId(id),
+  fTransform(tr),
+  fPickName(0),
+  fStartTime(-DBL_MAX),
+  fEndTime(DBL_MAX),
+  fpG4TextPlus(0),
+  fMarkerOrPolyline(false)
+{}
+
+G4OpenGLStoredSceneHandler::TO::~TO()
+{
+  delete fpG4TextPlus;
+}
+
+G4OpenGLStoredSceneHandler::TO& G4OpenGLStoredSceneHandler::TO::operator=
+  (const G4OpenGLStoredSceneHandler::TO& rhs)
+{
+  if (&rhs == this) return *this;
+  fDisplayListId = rhs.fDisplayListId;
+  fTransform = rhs.fTransform;
+  fPickName = rhs.fPickName;
+  fStartTime = rhs.fStartTime;
+  fEndTime = rhs.fEndTime;
+  fColour = rhs.fColour;
+  fpG4TextPlus = rhs.fpG4TextPlus? new G4TextPlus(*rhs.fpG4TextPlus): 0;
+  fMarkerOrPolyline = rhs.fMarkerOrPolyline;
+  return *this;
+}
+
+G4OpenGLStoredSceneHandler::G4OpenGLStoredSceneHandler
+(G4VGraphicsSystem& system,
+ const G4String& name):
+G4OpenGLSceneHandler (system, fSceneIdCount++, name),
+fTopPODL (0)
+{}
+
+G4OpenGLStoredSceneHandler::~G4OpenGLStoredSceneHandler ()
+{}
+
+void G4OpenGLStoredSceneHandler::BeginPrimitives
+(const G4Transform3D& objectTransformation)
+{  
+  G4OpenGLSceneHandler::BeginPrimitives (objectTransformation);
+  if (fReadyForTransients) glDrawBuffer (GL_FRONT);
+  // Display list setup moved to AddPrimitivePreamble.  See notes there.
+}
+
+void G4OpenGLStoredSceneHandler::EndPrimitives ()
+{
+  // See all primitives immediately...  At least soon...
+  ScaledFlush();
+  glDrawBuffer (GL_BACK);
+  G4OpenGLSceneHandler::EndPrimitives ();
+}
+
+void G4OpenGLStoredSceneHandler::BeginPrimitives2D
+(const G4Transform3D& objectTransformation)
+{
+  G4OpenGLSceneHandler::BeginPrimitives2D(objectTransformation);
+  if (fReadyForTransients) glDrawBuffer (GL_FRONT);
+}
+
+void G4OpenGLStoredSceneHandler::EndPrimitives2D ()
+{
+  // See all primitives immediately...  At least soon...
+  ScaledFlush();
+  glDrawBuffer (GL_BACK);
+  G4OpenGLSceneHandler::EndPrimitives2D ();
+}
+
+G4bool G4OpenGLStoredSceneHandler::AddPrimitivePreamble(const G4VMarker& visible)
+{
+  return AddPrimitivePreambleInternal(visible, true, false);
+}
+G4bool G4OpenGLStoredSceneHandler::AddPrimitivePreamble(const G4Polyline& visible)
+{
+  return AddPrimitivePreambleInternal(visible, false, true);
+}
+G4bool G4OpenGLStoredSceneHandler::AddPrimitivePreamble(const G4Polyhedron& visible)
+{
+  return AddPrimitivePreambleInternal(visible, false, false);
+}
+
+G4bool G4OpenGLStoredSceneHandler::AddPrimitivePreambleInternal(const G4Visible& visible, bool isMarker, bool isPolyline)
+{
+// Get applicable vis attributes for all primitives.
+  fpVisAttribs = fpViewer->GetApplicableVisAttributes(visible.GetVisAttributes());
+  const G4Colour& c = GetColour ();
+  G4double opacity = c.GetAlpha ();
+
+  G4bool transparency_enabled = true;
+  G4bool isMarkerNotHidden = true;
+  G4OpenGLViewer* pViewer = dynamic_cast<G4OpenGLViewer*>(fpViewer);
+  if (pViewer) {
+    transparency_enabled = pViewer->transparency_enabled;
+    isMarkerNotHidden = pViewer->fVP.IsMarkerNotHidden();
+  }
+  
+  G4bool isTransparent = opacity < 1.;
+  G4bool isMarkerOrPolyline = isMarker || isPolyline;
+  G4bool treatAsTransparent = transparency_enabled && isTransparent;
+  G4bool treatAsNotHidden = isMarkerNotHidden && isMarkerOrPolyline;
+  
+  if (fProcessing2D) glDisable (GL_DEPTH_TEST);
+  else {
+    if (isMarkerOrPolyline && isMarkerNotHidden)
+      glDisable (GL_DEPTH_TEST);
+    else {glEnable (GL_DEPTH_TEST); glDepthFunc (GL_LEQUAL);}
+  }
+
+  if (fThreePassCapable) {
+    
+    // Ensure transparent objects are drawn opaque ones and before
+    // non-hidden markers.  The problem of blending/transparency/alpha
+    // is quite a tricky one - see History of opengl-V07-01-01/2/3.
+    if (!(fSecondPassForTransparency || fThirdPassForNonHiddenMarkers)) {
+      // First pass...
+      if (treatAsTransparent) {  // Request pass for transparent objects...
+        fSecondPassForTransparencyRequested = true;
+      }
+      if (treatAsNotHidden) {    // Request pass for non-hidden markers...
+        fThirdPassForNonHiddenMarkersRequested = true;
+      }
+      // On first pass, transparent objects and non-hidden markers are not drawn...
+      if (treatAsTransparent || treatAsNotHidden) {
+        return false;  // No further processing.
+      }
+    }
+    
+    // On second pass, only transparent objects are drawn...
+    if (fSecondPassForTransparency) {
+      if (!treatAsTransparent) {
+        return false;  // No further processing.
+      }
+    }
+    
+    // On third pass, only non-hidden markers are drawn...
+    if (fThirdPassForNonHiddenMarkers) {
+      if (!treatAsNotHidden) {
+        return false;  // No further processing.
+        
+      }
+    }
+  }  // fThreePassCapable
+  
+  // Loads G4Atts for picking...
+  G4bool isPicking = false;
+  if (fpViewer->GetViewParameters().IsPicking()) {
+    isPicking = true;
+    glLoadName(++fPickName);
+    G4AttHolder* holder = new G4AttHolder;
+    LoadAtts(visible, holder);
+    fPickMap[fPickName] = holder;
+  }
+  
+  // Can we re-use a display list?
+  const G4VSolid* pSolid = 0;
+  G4PhysicalVolumeModel* pPVModel =
+  dynamic_cast<G4PhysicalVolumeModel*>(fpModel);
+  if (fpViewer->GetViewParameters().GetVisAttributesModifiers().size())
+    // Touchables have been modified - don't risk re-using display list.
+    goto end_of_display_list_reuse_test;
+  if (pPVModel) {
+    // Check that it isn't a G4LogicalVolumeModel (which is a sub-class of
+    // G4PhysicalVolumeModel).
+    G4LogicalVolumeModel* pLVModel =
+    dynamic_cast<G4LogicalVolumeModel*>(pPVModel);
+    if (pLVModel)
+      // Logical volume model - don't re-use.
+      goto end_of_display_list_reuse_test;
+    if (pViewer->fVP.IsSection() || pViewer->fVP.IsCutaway())
+      // sections and cutaways generate unique views of each model instance
+      goto end_of_display_list_reuse_test;
+    // If part of the geometry hierarchy, i.e., from a
+    // G4PhysicalVolumeModel, check if a display list already exists for
+    // this solid, re-use it if possible.  We could be smarter, and
+    // recognise repeated branches of the geometry hierarchy, for
+    // example.  But this algorithm should be secure, I think...
+    G4VPhysicalVolume* pPV = pPVModel->GetCurrentPV();
+    if (!pPV)
+      // It's probably a dummy model, e.g., for a user-drawn hit?
+      goto end_of_display_list_reuse_test;
+    G4LogicalVolume* pLV = pPV->GetLogicalVolume();
+    if (!pLV)
+      // Dummy model again?
+      goto end_of_display_list_reuse_test;
+    pSolid = pLV->GetSolid();
+    EAxis axis = kRho;
+    G4VPhysicalVolume* pCurrentPV = pPVModel->GetCurrentPV();
+    if (pCurrentPV -> IsReplicated ()) {
+      G4int nReplicas;
+      G4double width;
+      G4double offset;
+      G4bool consuming;
+      pCurrentPV->GetReplicationData(axis,nReplicas,width,offset,consuming);
+    }
+    // Provided it is not parametrised (because if so, the
+    // solid's parameters might have been changed)...
+    if (!(pCurrentPV -> IsParameterised ()) &&
+        // Provided it is not replicated radially (because if so, the
+        // solid's parameters will have been changed)...
+        !(pCurrentPV -> IsReplicated () && axis == kRho) &&
+        // ...and if the solid has already been rendered...
+        (fSolidMap.find (pSolid) != fSolidMap.end ())) {
+      fDisplayListId = fSolidMap [pSolid];
+      PO po(fDisplayListId,fObjectTransformation);
+      if (isPicking) po.fPickName = fPickName;
+      po.fColour = c;
+      po.fMarkerOrPolyline = isMarkerOrPolyline;
+      fPOList.push_back(po);
+      // No need to test if gl commands are used (result of
+      // ExtraPOProcessing) because we have already decided they will
+      // not, at least not here.  Also, pass a dummy G4Visible since
+      // not relevant for G4PhysicalVolumeModel.
+      (void) ExtraPOProcessing(G4Visible(), fPOList.size() - 1);
+      return false;  // No further processing.
+    }
+  }
+end_of_display_list_reuse_test:
+
+  // Because of our need to control colour of transients (display by
+  // time fading), display lists may only cover a single primitive.
+  // So display list setup is here.
+  
+  if (fMemoryForDisplayLists) {
+    fDisplayListId = glGenLists (1);
+    if (glGetError() == GL_OUT_OF_MEMORY ||
+	fDisplayListId > fDisplayListLimit) {
+      G4cout <<
+      "********************* WARNING! ********************"
+      "\n*  Display list limit reached in OpenGL."
+      "\n*  Continuing drawing WITHOUT STORING. Scene only partially refreshable."
+      "\n*  Current limit: " << fDisplayListLimit <<
+      ".  Change with \"/vis/ogl/set/displayListLimit\"."
+      "\n***************************************************"
+      << G4endl;
+      fMemoryForDisplayLists = false;
+    }
+  }
+  
+  if (pSolid) fSolidMap [pSolid] = fDisplayListId;
+
+  if (fMemoryForDisplayLists) {
+    if (fReadyForTransients) {
+      TO to(fDisplayListId, fObjectTransformation);
+      if (isPicking) to.fPickName = fPickName;
+      to.fColour = c;
+      to.fStartTime = fpVisAttribs->GetStartTime();
+      to.fEndTime = fpVisAttribs->GetEndTime();
+      to.fMarkerOrPolyline = isMarkerOrPolyline;
+      fTOList.push_back(to);
+      // For transient objects, colour, transformation, are kept in
+      // the TO, so should *not* be in the display list.  As mentioned
+      // above, in some cases (display-by-time fading) we need to have
+      // independent control of colour.  But for now transform and set
+      // colour for immediate display.
+      glPushMatrix();
+      G4OpenGLTransform3D oglt (fObjectTransformation);
+      glMultMatrixd (oglt.GetGLMatrix ());
+      if (transparency_enabled) {
+        glColor4d(c.GetRed(),c.GetGreen(),c.GetBlue(),c.GetAlpha());
+      } else {
+        glColor3d(c.GetRed(),c.GetGreen(),c.GetBlue());
+      }
+      (void) ExtraTOProcessing(visible, fTOList.size() - 1);
+      // Ignore return value of the above.  If this visible does not use
+      // gl commands, a display list is created that is empty and not
+      // used.
+      glNewList (fDisplayListId, GL_COMPILE_AND_EXECUTE);
+    } else {
+      PO po(fDisplayListId, fObjectTransformation);
+      if (isPicking) po.fPickName = fPickName;
+      po.fColour = c;
+      po.fMarkerOrPolyline = isMarkerOrPolyline;
+      fPOList.push_back(po);
+      // For permanent objects, colour is kept in the PO, so should
+      // *not* be in the display list.  This is so that sub-classes
+      // may implement colour modifications according to their own
+      // criteria, e.g., scen tree slider in Qt.  But for now set
+      // colour for immediate display.
+      if (transparency_enabled) {
+        glColor4d(c.GetRed(),c.GetGreen(),c.GetBlue(),c.GetAlpha());
+      } else {
+        glColor3d(c.GetRed(),c.GetGreen(),c.GetBlue());
+      }
+      G4bool usesGLCommands = ExtraPOProcessing(visible, fPOList.size() - 1);
+      // Transients are displayed as they come (GL_COMPILE_AND_EXECUTE
+      // above) but persistents are compiled into display lists
+      // (GL_COMPILE only) and then drawn from the display lists with
+      // their fObjectTransformation as stored in fPOList.  Thus,
+      // there is no need to do glMultMatrixd here.  If
+      // ExtraPOProcessing says the visible object does not use gl
+      // commands, simply return and abandon further processing.  It
+      // is assumed that all relevant information is kept in the
+      // POList.
+      if (!usesGLCommands) return false;
+      glNewList (fDisplayListId, GL_COMPILE);
+    }
+  } else {  // Out of memory (or being used when display lists not required).
+    glDrawBuffer (GL_FRONT);
+    glPushMatrix();
+    G4OpenGLTransform3D oglt (fObjectTransformation);
+    glMultMatrixd (oglt.GetGLMatrix ());
+    if (transparency_enabled) {
+      glColor4d(c.GetRed(),c.GetGreen(),c.GetBlue(),c.GetAlpha());
+    } else {
+      glColor3d(c.GetRed(),c.GetGreen(),c.GetBlue());
+    }
+  }
+
+  if (fProcessing2D) {
+    // Push current 3D world matrices and load identity to define screen
+    // coordinates...
+    glMatrixMode (GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    if (pViewer) {
+      pViewer->g4GlOrtho (-1., 1., -1., 1., -G4OPENGL_FLT_BIG, G4OPENGL_FLT_BIG);
+    }
+    glMatrixMode (GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+    G4OpenGLTransform3D oglt (fObjectTransformation);
+    glMultMatrixd (oglt.GetGLMatrix ());
+    glDisable (GL_LIGHTING);
+  } else {
+    glEnable (GL_LIGHTING);
+  }
+
+  return true;
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitivePostamble()
+{
+  if (fProcessing2D) {
+    // Pop current 3D world matrices back again...
+    glMatrixMode (GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode (GL_MODELVIEW);
+    glPopMatrix();
+  }
+
+  //  if ((glGetError() == GL_TABLE_TOO_LARGE) || (glGetError() == GL_OUT_OF_MEMORY)) {  // Could close?
+  if (glGetError() == GL_OUT_OF_MEMORY) {  // Could close?
+    G4cerr <<
+      "ERROR: G4OpenGLStoredSceneHandler::AddPrimitivePostamble: Failure"
+      "  to allocate display List for fTopPODL - try OpenGL Immediated mode."
+           << G4endl;
+  }
+  if (fMemoryForDisplayLists) {
+    glEndList();
+    if (glGetError() == GL_OUT_OF_MEMORY) {  // Could close?
+      G4cerr <<
+        "ERROR: G4OpenGLStoredSceneHandler::AddPrimitivePostamble: Failure"
+	"  to allocate display List for fTopPODL - try OpenGL Immediated mode."
+             << G4endl;
+    }
+  }
+  if (fReadyForTransients || !fMemoryForDisplayLists) {
+    glPopMatrix();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Polyline& polyline)
+{
+  G4bool furtherprocessing = AddPrimitivePreamble(polyline);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(polyline);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Polymarker& polymarker)
+{
+  G4bool furtherprocessing = AddPrimitivePreamble(polymarker);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(polymarker);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Text& text)
+{
+  // Note: colour is still handled in
+  // G4OpenGLSceneHandler::AddPrimitive(const G4Text&), so it still
+  // gets into the display list
+  G4bool furtherprocessing = AddPrimitivePreamble(text);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(text);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Circle& circle)
+{
+  G4bool furtherprocessing = AddPrimitivePreamble(circle);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(circle);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Square& square)
+{
+  G4bool furtherprocessing = AddPrimitivePreamble(square);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(square);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Scale& scale)
+{
+  // Let base class split into primitives.
+  G4OpenGLSceneHandler::AddPrimitive(scale);
+}
+
+void G4OpenGLStoredSceneHandler::AddPrimitive (const G4Polyhedron& polyhedron)
+{
+  // Note: colour is still handled in
+  // G4OpenGLSceneHandler::AddPrimitive(const G4Polyhedron&), so it still
+  // gets into the display list
+  G4bool furtherprocessing = AddPrimitivePreamble(polyhedron);
+  if (furtherprocessing) {
+    G4OpenGLSceneHandler::AddPrimitive(polyhedron);
+    AddPrimitivePostamble();
+  }
+}
+
+void G4OpenGLStoredSceneHandler::BeginModeling () {
+  G4VSceneHandler::BeginModeling();
+  /* Debug...
+  fDisplayListId = glGenLists (1);
+  G4cout << "OGL::fDisplayListId (start): " << fDisplayListId << G4endl;
+  */
+}
+
+void G4OpenGLStoredSceneHandler::EndModeling () {
+  // Make a List which calls the other lists.
+  fTopPODL = glGenLists (1);
+  if (glGetError() == GL_OUT_OF_MEMORY) {  // Could pre-allocate?
+    G4cerr <<
+      "ERROR: G4OpenGLStoredSceneHandler::EndModeling: Failure to allocate"
+      "  display List for fTopPODL - try OpenGL Immediated mode."
+	   << G4endl;
+  } else {
+
+    glNewList (fTopPODL, GL_COMPILE); {
+      for (size_t i = 0; i < fPOList.size (); i++) {
+	glPushMatrix();
+	G4OpenGLTransform3D oglt (fPOList[i].fTransform);
+	glMultMatrixd (oglt.GetGLMatrix ());
+	if (fpViewer->GetViewParameters().IsPicking())
+	  glLoadName(fPOList[i].fPickName);
+	glCallList (fPOList[i].fDisplayListId);
+	glPopMatrix();
+      }
+    }
+    glEndList ();
+
+    if (glGetError() == GL_OUT_OF_MEMORY) {  // Could close?
+      G4cerr <<
+        "ERROR: G4OpenGLStoredSceneHandler::EndModeling: Failure to allocate"
+        "  display List for fTopPODL - try OpenGL Immediated mode."
+             << G4endl;
+    }
+  }
+
+  G4VSceneHandler::EndModeling ();
+}
+
+void G4OpenGLStoredSceneHandler::ClearStore () {
+
+  //G4cout << "G4OpenGLStoredSceneHandler::ClearStore" << G4endl;
+
+  G4VSceneHandler::ClearStore ();  // Sets need kernel visit, etc.
+
+  // Delete OpenGL permanent display lists.
+  for (size_t i = 0; i < fPOList.size (); i++)
+    glDeleteLists (fPOList[i].fDisplayListId, 1);
+  if (fTopPODL) glDeleteLists (fTopPODL, 1);
+  fTopPODL = 0;
+
+  // Clear other lists, dictionary, etc.
+  fPOList.clear ();
+  fSolidMap.clear ();
+  ClearAndDestroyAtts();
+
+  // ...and clear transient store...
+  for (size_t i = 0; i < fTOList.size (); i++)
+    glDeleteLists(fTOList[i].fDisplayListId, 1);
+  fTOList.clear ();
+
+  fMemoryForDisplayLists = true;
+}
+
+void G4OpenGLStoredSceneHandler::ClearTransientStore ()
+{
+  //G4cout << "G4OpenGLStoredSceneHandler::ClearTransientStore" << G4endl;
+
+  // Delete OpenGL transient display lists and Transient Objects themselves.
+  for (size_t i = 0; i < fTOList.size (); i++)
+    glDeleteLists(fTOList[i].fDisplayListId, 1);
+  fTOList.clear ();
+
+  fMemoryForDisplayLists = true;
+
+  // Redraw the scene ready for the next event.
+  if (fpViewer) {
+    fpViewer -> SetView ();
+    fpViewer -> ClearView ();
+    fpViewer -> DrawView ();
+  }
+}
+
+
+#endif

--- a/src/G4.10.03.p01fixes/G4OpenGLViewer.cc
+++ b/src/G4.10.03.p01fixes/G4OpenGLViewer.cc
@@ -1,0 +1,1621 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4OpenGLViewer.cc 101714 2016-11-22 08:53:13Z gcosmo $
+//
+// 
+// Andrew Walkden  27th March 1996
+// OpenGL view - opens window, hard copy, etc.
+
+#ifdef G4VIS_BUILD_OPENGL_DRIVER
+
+#include "G4ios.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4OpenGLViewer.hh"
+#include "G4OpenGLSceneHandler.hh"
+#include "G4OpenGLTransform3D.hh"
+#include "G4OpenGL2PSAction.hh"
+
+#include "G4TransportationManager.hh"
+#include "G4Navigator.hh"
+#include "G4Material.hh"
+#include "G4FieldManager.hh"
+#include "G4Field.hh"
+
+#include "G4Scene.hh"
+#include "G4VisExtent.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VSolid.hh"
+#include "G4Point3D.hh"
+#include "G4Normal3D.hh"
+#include "G4Plane3D.hh"
+#include "G4AttHolder.hh"
+#include "G4AttCheck.hh"
+#include "G4Text.hh"
+
+#ifdef G4OPENGL_VERSION_2
+// We need to have a Wt gl drawer because we will draw inside the WtGL component (ImmediateWtViewer)
+#include "G4OpenGLVboDrawer.hh"
+#endif
+
+// GL2PS
+#include "Geant4_gl2ps.h"
+
+#include <sstream>
+#include <string>
+#include <iomanip>
+
+#include <GL/glu.h>
+
+G4OpenGLViewer::G4OpenGLViewer (G4OpenGLSceneHandler& scene):
+G4VViewer (scene, -1),
+#ifdef G4OPENGL_VERSION_2
+fVboDrawer(NULL),
+#endif
+fPrintColour (true),
+fVectoredPs (true),
+fOpenGLSceneHandler(scene),
+background (G4Colour(0.,0.,0.)),
+transparency_enabled (true),
+antialiasing_enabled (false),
+haloing_enabled (false),
+fStartTime(-DBL_MAX),
+fEndTime(DBL_MAX),
+fFadeFactor(0.),
+fDisplayHeadTime(false),
+fDisplayHeadTimeX(-0.9),
+fDisplayHeadTimeY(-0.9),
+fDisplayHeadTimeSize(24.),
+fDisplayHeadTimeRed(0.),
+fDisplayHeadTimeGreen(1.),
+fDisplayHeadTimeBlue(1.),
+fDisplayLightFront(false),
+fDisplayLightFrontX(0.),
+fDisplayLightFrontY(0.),
+fDisplayLightFrontZ(0.),
+fDisplayLightFrontT(0.),
+fDisplayLightFrontRed(0.),
+fDisplayLightFrontGreen(1.),
+fDisplayLightFrontBlue(0.),
+fRot_sens(1.),
+fPan_sens(0.01),
+fWinSize_x(0),
+fWinSize_y(0),
+fDefaultExportImageFormat("pdf"),
+fExportImageFormat("pdf"),
+fExportFilenameIndex(0),
+fPrintSizeX(-1),
+fPrintSizeY(-1),
+fPointSize (0),
+fDefaultExportFilename("G4OpenGL"),
+fSizeHasChanged(0),
+fGl2psDefaultLineWith(1),
+fGl2psDefaultPointSize(2),
+fGlViewInitialized(false),
+fIsGettingPickInfos(false)
+#ifdef G4OPENGL_VERSION_2
+,fShaderProgram(0)
+,fVertexPositionAttribute(0)
+,fVertexNormalAttribute(0)
+,fpMatrixUniform(0)
+,fcMatrixUniform(0)
+,fmvMatrixUniform(0)
+,fnMatrixUniform(0)
+#endif
+{
+  // Make changes to view parameters for OpenGL...
+  fVP.SetAutoRefresh(true);
+  fDefaultVP.SetAutoRefresh(true);
+
+  fGL2PSAction = new G4OpenGL2PSAction();
+
+  // add supported export image format
+  addExportImageFormat("eps");
+  addExportImageFormat("ps");
+  addExportImageFormat("pdf");
+  addExportImageFormat("svg");
+
+  // Change the default name
+  fExportFilename += fDefaultExportFilename + "_" + GetShortName().data();
+  
+  //  glClearColor (0.0, 0.0, 0.0, 0.0);
+  //  glClearDepth (1.0);
+  //  glDisable (GL_BLEND);
+  //  glDisable (GL_LINE_SMOOTH);
+  //  glDisable (GL_POLYGON_SMOOTH);
+
+}
+
+G4OpenGLViewer::~G4OpenGLViewer ()
+{
+  delete fGL2PSAction;
+}
+
+void G4OpenGLViewer::InitializeGLView () 
+{
+#ifdef G4OPENGL_VERSION_2
+  if (fVboDrawer) {
+    
+    // First, load a simple shader
+    fShaderProgram = glCreateProgram();
+    Shader vertexShader = glCreateShader(GL_VERTEX_SHADER);
+    const char * vSrc = fVboDrawer->getVertexShaderSrc();
+    glShaderSource(vertexShader, 1, &vSrc, NULL);
+    glCompileShader(vertexShader);
+    glAttachShader(fShaderProgram, vertexShader);
+    
+    Shader fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+    const char * fSrc = fVboDrawer->getFragmentShaderSrc();
+    glShaderSource(fragmentShader, 1, &fSrc, NULL);
+    glCompileShader(fragmentShader);
+    
+    glAttachShader(fShaderProgram, fragmentShader);
+    glLinkProgram(fShaderProgram);
+    glUseProgram(fShaderProgram);
+    
+    //   UniformLocation uColor = getUniformLocation(fShaderProgram, "uColor");
+    //   uniform4fv(uColor, [0.0, 0.3, 0.0, 1.0]);
+    
+    // Extract the references to the attributes from the shader.
+    
+    fVertexPositionAttribute =
+    glGetAttribLocation(fShaderProgram, "aVertexPosition");
+    
+    
+    glEnableVertexAttribArray(fVertexPositionAttribute);
+    
+    // Extract the references the uniforms from the shader
+    fpMatrixUniform  = glGetUniformLocation(fShaderProgram, "uPMatrix");
+    fcMatrixUniform  = glGetUniformLocation(fShaderProgram, "uCMatrix");
+    fmvMatrixUniform = glGetUniformLocation(fShaderProgram, "uMVMatrix");
+    fnMatrixUniform  = glGetUniformLocation(fShaderProgram, "uNMatrix");
+    ftMatrixUniform  = glGetUniformLocation(fShaderProgram, "uTMatrix");
+    
+    /*    glUniformMatrix4fv(fcMatrixUniform, 1, 0, identity);
+     glUniformMatrix4fv(fpMatrixUniform, 1, 0, identity);
+     glUniformMatrix4fv(ftMatrixUniform, 1, 0, identity);
+     glUniformMatrix4fv(fmvMatrixUniform, 1, 0, identity);
+     */
+    // We have to set that in order to avoid calls on opengl commands before all is ready
+    fGlViewInitialized = true;
+  }
+#endif
+  
+  if (fWinSize_x == 0) {
+    fWinSize_x = fVP.GetWindowSizeHintX();
+  }
+  if (fWinSize_y == 0) {
+    fWinSize_y = fVP.GetWindowSizeHintY();
+  }
+
+  glClearColor (0.0, 0.0, 0.0, 0.0);
+  glClearDepth (1.0);
+#ifndef G4OPENGL_VERSION_2
+  glDisable (GL_LINE_SMOOTH);
+  glDisable (GL_POLYGON_SMOOTH);
+#endif
+
+// clear the buffers and window?
+  ClearView ();
+  FinishView ();
+  
+  glDepthFunc (GL_LEQUAL);
+  glDepthMask (GL_TRUE);
+  
+  glEnable (GL_BLEND);
+  glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  
+}
+
+void G4OpenGLViewer::ClearView () {
+  ClearViewWithoutFlush();
+
+  if(!isFramebufferReady()) {
+    return;
+  }
+
+  glFlush();
+}
+
+
+void G4OpenGLViewer::ClearViewWithoutFlush () {
+  // Ready for clear ?
+  // See : http://lists.apple.com/archives/mac-opengl/2012/Jul/msg00038.html
+  if(!isFramebufferReady()) {
+    return;
+  }
+  
+  glClearColor (background.GetRed(),
+                background.GetGreen(),
+                background.GetBlue(),
+                1.);
+  glClearDepth (1.0);
+  //Below line does not compile with Mesa includes.
+  //glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  glClear (GL_COLOR_BUFFER_BIT);
+  glClear (GL_DEPTH_BUFFER_BIT);
+  glClear (GL_STENCIL_BUFFER_BIT);
+}
+
+
+void G4OpenGLViewer::ResizeWindow(unsigned int aWidth, unsigned int aHeight) {
+  if ((fWinSize_x != aWidth) || (fWinSize_y != aHeight)) {
+    fWinSize_x = aWidth;
+    fWinSize_y = aHeight;
+    fSizeHasChanged = true;
+  } else {
+    fSizeHasChanged = false;
+  }
+}
+
+/**
+ * Set the viewport of the scene
+ * MAXIMUM SIZE is :
+ * GLint dims[2];
+ * glGetIntegerv(GL_MAX_VIEWPORT_DIMS, dims);
+ */
+void G4OpenGLViewer::ResizeGLView()
+{
+  // Check size
+  GLint dims[2];
+  dims[0] = 0;
+  dims[1] = 0;
+
+  glGetIntegerv(GL_MAX_VIEWPORT_DIMS, dims);
+
+  if ((dims[0] !=0 ) && (dims[1] !=0)) {
+
+    if (fWinSize_x > (unsigned)dims[0]) {
+      G4cerr << "Try to resize view greater than max X viewport dimension. Desired size "<<fWinSize_x <<" is resize to "<<  dims[0] << G4endl;
+      fWinSize_x = dims[0];
+    }
+    if (fWinSize_y > (unsigned)dims[1]) {
+      G4cerr << "Try to resize view greater than max Y viewport dimension. Desired size "<<fWinSize_y <<" is resize to "<<  dims[1] << G4endl;
+      fWinSize_y = dims[1];
+    }
+  }
+    
+  glViewport(0, 0, fWinSize_x,fWinSize_y);   
+
+
+}
+
+
+void G4OpenGLViewer::SetView () {
+  // if getting pick infos, should not resize the view.
+  if (fIsGettingPickInfos) return;
+  
+  if (!fSceneHandler.GetScene()) {
+    return;
+  }
+  // Calculates view representation based on extent of object being
+  // viewed and (initial) viewpoint.  (Note: it can change later due
+  // to user interaction via visualization system's GUI.)
+  
+  // Lighting.
+  GLfloat lightPosition [4];
+  lightPosition [0] = fVP.GetActualLightpointDirection().x();
+  lightPosition [1] = fVP.GetActualLightpointDirection().y();
+  lightPosition [2] = fVP.GetActualLightpointDirection().z();
+  lightPosition [3] = 0.;
+  // Light position is "true" light direction, so must come after gluLookAt.
+  GLfloat ambient [] = { 0.2f, 0.2f, 0.2f, 1.f};
+  GLfloat diffuse [] = { 0.8f, 0.8f, 0.8f, 1.f};
+  glEnable (GL_LIGHT0);
+  glLightfv (GL_LIGHT0, GL_AMBIENT, ambient);
+  glLightfv (GL_LIGHT0, GL_DIFFUSE, diffuse);
+  
+  G4double ratioX = 1;
+  G4double ratioY = 1;
+  if (fWinSize_y > fWinSize_x) {
+    ratioX = ((G4double)fWinSize_y) / ((G4double)fWinSize_x);
+  }
+  if (fWinSize_x > fWinSize_y) {
+    ratioY = ((G4double)fWinSize_x) / ((G4double)fWinSize_y);
+  }
+  
+  // Get radius of scene, etc.
+  // Note that this procedure properly takes into account zoom, dolly and pan.
+  const G4Point3D targetPoint
+    = fSceneHandler.GetScene()->GetStandardTargetPoint()
+    + fVP.GetCurrentTargetPoint ();
+  G4double radius = fSceneHandler.GetScene()->GetExtent().GetExtentRadius();
+  if(radius<=0.) radius = 1.;
+  const G4double cameraDistance = fVP.GetCameraDistance (radius);
+  const G4Point3D cameraPosition =
+    targetPoint + cameraDistance * fVP.GetViewpointDirection().unit();
+  const GLdouble pnear  = fVP.GetNearDistance (cameraDistance, radius);
+  const GLdouble pfar   = fVP.GetFarDistance  (cameraDistance, pnear, radius);
+  const GLdouble right  = fVP.GetFrontHalfHeight (pnear, radius) * ratioY;
+  const GLdouble left   = -right;
+  const GLdouble top    = fVP.GetFrontHalfHeight (pnear, radius) * ratioX;
+  const GLdouble bottom = -top;
+  
+  // FIXME
+  ResizeGLView();
+  //SHOULD SetWindowsSizeHint()...
+
+  glMatrixMode (GL_PROJECTION); // set up Frustum.
+  glLoadIdentity();
+
+  const G4Vector3D scaleFactor = fVP.GetScaleFactor();
+  glScaled(scaleFactor.x(),scaleFactor.y(),scaleFactor.z());
+  
+  if (fVP.GetFieldHalfAngle() == 0.) {
+    g4GlOrtho (left, right, bottom, top, pnear, pfar);
+  }
+  else {
+    g4GlFrustum (left, right, bottom, top, pnear, pfar);
+  }  
+
+  glMatrixMode (GL_MODELVIEW); // apply further transformations to scene.
+  glLoadIdentity();
+  
+  const G4Normal3D& upVector = fVP.GetUpVector ();  
+  G4Point3D gltarget;
+  if (cameraDistance > 1.e-6 * radius) {
+    gltarget = targetPoint;
+  }
+  else {
+    gltarget = targetPoint - radius * fVP.GetViewpointDirection().unit();
+  }
+
+  const G4Point3D& pCamera = cameraPosition;  // An alias for brevity.
+
+  g4GluLookAt (pCamera.x(),  pCamera.y(),  pCamera.z(),       // Viewpoint.
+             gltarget.x(), gltarget.y(), gltarget.z(),      // Target point.
+             upVector.x(), upVector.y(), upVector.z());     // Up vector.
+  // Light position is "true" light direction, so must come after gluLookAt.
+  glLightfv (GL_LIGHT0, GL_POSITION, lightPosition);
+
+  // The idea is to use back-to-back clipping planes.  This can cut an object
+  // down to just a few pixels, which can make it difficult to see.  So, for
+  // now, comment this out and use the generic (Boolean) method, via
+  // G4VSolid* G4OpenGLSceneHandler::CreateSectionSolid ()
+  // { return G4VSceneHandler::CreateSectionSolid(); }
+//  if (fVP.IsSection () ) {  // pair of back to back clip planes.
+//    const G4Plane3D& sp = fVP.GetSectionPlane ();
+//    double sArray[4];
+//    sArray[0] = sp.a();
+//    sArray[1] = sp.b();
+//    sArray[2] = sp.c();
+//    sArray[3] = sp.d() + radius * 1.e-05;
+//    glClipPlane (GL_CLIP_PLANE0, sArray);
+//    glEnable (GL_CLIP_PLANE0);
+//    sArray[0] = -sp.a();
+//    sArray[1] = -sp.b();
+//    sArray[2] = -sp.c();
+//    sArray[3] = -sp.d() + radius * 1.e-05;
+//    glClipPlane (GL_CLIP_PLANE1, sArray);
+//    glEnable (GL_CLIP_PLANE1);
+//  } else {
+//    glDisable (GL_CLIP_PLANE0);
+//    glDisable (GL_CLIP_PLANE1);
+//  }
+
+  // What we call intersection of cutaways is easy in OpenGL.  You
+  // just keep cutting.  Unions are more tricky - you have to have
+  // multiple passes and this is handled in
+  // G4OpenGLImmediate/StoredViewer::ProcessView.
+  const G4Planes& cutaways = fVP.GetCutawayPlanes();
+  size_t nPlanes = cutaways.size();
+  if (fVP.IsCutaway() &&
+      fVP.GetCutawayMode() == G4ViewParameters::cutawayIntersection &&
+      nPlanes > 0) {
+    double a[4];
+    a[0] = cutaways[0].a();
+    a[1] = cutaways[0].b();
+    a[2] = cutaways[0].c();
+    a[3] = cutaways[0].d();
+    glClipPlane (GL_CLIP_PLANE2, a);
+    glEnable (GL_CLIP_PLANE2);
+    if (nPlanes > 1) {
+      a[0] = cutaways[1].a();
+      a[1] = cutaways[1].b();
+      a[2] = cutaways[1].c();
+      a[3] = cutaways[1].d();
+      glClipPlane (GL_CLIP_PLANE3, a);
+      glEnable (GL_CLIP_PLANE3);
+    }
+    if (nPlanes > 2) {
+      a[0] = cutaways[2].a();
+      a[1] = cutaways[2].b();
+      a[2] = cutaways[2].c();
+      a[3] = cutaways[2].d();
+      glClipPlane (GL_CLIP_PLANE4, a);
+      glEnable (GL_CLIP_PLANE4);
+    }
+  } else {
+    glDisable (GL_CLIP_PLANE2);
+    glDisable (GL_CLIP_PLANE3);
+    glDisable (GL_CLIP_PLANE4);
+  }
+
+  // Background.
+  background = fVP.GetBackgroundColour ();
+
+}
+
+
+
+void G4OpenGLViewer::ResetView () {
+  G4VViewer::ResetView();
+  fRot_sens = 1;
+  fPan_sens = 0.01;
+}
+
+
+void G4OpenGLViewer::HaloingFirstPass () {
+  
+  //To perform haloing, first Draw all information to the depth buffer
+  //alone, using a chunky line width, and then Draw all info again, to
+  //the colour buffer, setting a thinner line width an the depth testing 
+  //function to less than or equal, so if two lines cross, the one 
+  //passing behind the other will not pass the depth test, and so not
+  //get rendered either side of the infront line for a short distance.
+
+  //First, disable writing to the colo(u)r buffer...
+  glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
+  //Now enable writing to the depth buffer...
+  glDepthMask (GL_TRUE);
+  glDepthFunc (GL_LESS);
+  glClearDepth (1.0);
+
+  //Finally, set the line width to something wide...
+  ChangeLineWidth(3.0);
+
+}
+
+void G4OpenGLViewer::HaloingSecondPass () {
+
+  //And finally, turn the colour buffer back on with a sesible line width...
+  glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  glDepthFunc (GL_LEQUAL);
+  ChangeLineWidth(1.0);
+
+}
+
+G4String G4OpenGLViewer::Pick(GLdouble x, GLdouble y)
+{
+  std::vector < G4OpenGLViewerPickMap* >  pickMap = GetPickDetails(x,y);
+  G4String txt = "";
+  if (pickMap.size() == 0) {
+    txt += "Too many hits.  Zoom in to reduce overlaps.";;
+  } else {
+#ifdef LAYERED_GEOMETRY_PICKING_EXTENSIONS
+    G4ThreeVector xlast;
+    for (unsigned int a = 0; a < pickMap.size(); a++) {
+      G4ThreeVector x = pickMap[a]->getPickCoordinates3D();
+      if (!x.isNear(xlast, 0.001 * cm)) {
+        txt += pickMap[a]->print();
+        xlast = x;
+      }
+    }
+#else
+    for (unsigned int a=0; a< pickMap.size(); a++) {
+      txt += pickMap[a]->print();
+    }
+#endif
+  }
+  return txt;
+}
+
+std::vector < G4OpenGLViewerPickMap* > G4OpenGLViewer::GetPickDetails(GLdouble x, GLdouble y)
+{
+  std::vector < G4OpenGLViewerPickMap* > pickMapVector;
+  
+  const G4int BUFSIZE = 512;
+  GLuint selectBuffer[BUFSIZE];
+  glSelectBuffer(BUFSIZE, selectBuffer);
+  glRenderMode(GL_SELECT);
+  glInitNames();
+  glPushName(0);
+  glMatrixMode(GL_PROJECTION);
+  G4double currentProjectionMatrix[16];
+  glGetDoublev(GL_PROJECTION_MATRIX, currentProjectionMatrix);
+  glPushMatrix();
+  glLoadIdentity();
+  GLint viewport[4];
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  fIsGettingPickInfos = true;
+  // Define 5x5 pixel pick area
+  g4GluPickMatrix(x, viewport[3] - y, 5., 5., viewport);
+  glMultMatrixd(currentProjectionMatrix);
+  glMatrixMode(GL_MODELVIEW);
+  DrawView();
+  GLint hits = glRenderMode(GL_RENDER);
+  fIsGettingPickInfos = false;
+  if (hits > 0) {
+    
+    GLuint* p = selectBuffer;
+    for (GLint i = 0; i < hits; ++i) {
+      G4OpenGLViewerPickMap* pickMap = new G4OpenGLViewerPickMap();
+      GLuint nnames = *p++;
+#ifdef LAYERED_GEOMETRY_PICKING_EXTENSIONS
+      double zmin = *p++;
+      double zmax = *p++;
+      zmin /= (1LL << 32) - 1.0;
+      zmax /= (1LL << 32) - 1.0;
+      double model[16];
+      double proj[16];
+      GLint view[4];
+      double gx[4];
+      glGetDoublev(GL_MODELVIEW_MATRIX,model);
+      glGetDoublev(GL_PROJECTION_MATRIX,proj);
+      glGetIntegerv(GL_VIEWPORT,view);
+      gluUnProject(x,y,(zmin+zmax)/2,model,proj,view,&gx[0],&gx[1],&gx[2]);
+      pickMap->setPickCoordinates3D(G4ThreeVector(gx[0],gx[1],gx[2]));
+#else
+      // This bit of debug code or...
+      //GLuint zmin = *p++;
+      //GLuint zmax = *p++;
+      //G4cout << "Hit " << i << ": " << nnames << " names"
+      //       << "\nzmin: " << zmin << ", zmax: " << zmax << G4endl;
+      // ...just increment the pointer
+      p++;
+      p++;
+#endif
+      for (GLuint j = 0; j < nnames; ++j) {
+        GLuint name = *p++;
+        pickMap->setHitNumber(i);
+        pickMap->setSubHitNumber(j);
+        pickMap->setPickName(name);
+	std::map<GLuint, G4AttHolder*>::iterator iter =
+	  fOpenGLSceneHandler.fPickMap.find(name);
+	if (iter != fOpenGLSceneHandler.fPickMap.end()) {
+	  G4AttHolder* attHolder = iter->second;
+	  if(attHolder && attHolder->GetAttDefs().size()) {
+	    for (size_t iAtt = 0;
+		 iAtt < attHolder->GetAttDefs().size(); ++iAtt) {
+              std::ostringstream oss;
+	      oss << G4AttCheck(attHolder->GetAttValues()[iAtt],
+                                attHolder->GetAttDefs()[iAtt]);
+              pickMap->addAttributes(oss.str());
+            }
+          }
+        }
+      }
+      pickMapVector.push_back(pickMap);
+    }
+  }
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+  return pickMapVector;
+}
+
+GLubyte* G4OpenGLViewer::grabPixels
+(int inColor, unsigned int width, unsigned int height) {
+  
+  GLubyte* buffer;
+  GLint swapbytes, lsbfirst, rowlength;
+  GLint skiprows, skippixels, alignment;
+  GLenum format;
+  int size;
+
+  if (inColor) {
+    format = GL_RGB;
+    size = width*height*3;
+  } else {
+    format = GL_LUMINANCE;
+    size = width*height*1;
+  }
+
+  buffer = new GLubyte[size];
+  if (buffer == NULL)
+    return NULL;
+
+  glGetIntegerv (GL_UNPACK_SWAP_BYTES, &swapbytes);
+  glGetIntegerv (GL_UNPACK_LSB_FIRST, &lsbfirst);
+  glGetIntegerv (GL_UNPACK_ROW_LENGTH, &rowlength);
+
+  glGetIntegerv (GL_UNPACK_SKIP_ROWS, &skiprows);
+  glGetIntegerv (GL_UNPACK_SKIP_PIXELS, &skippixels);
+  glGetIntegerv (GL_UNPACK_ALIGNMENT, &alignment);
+
+  glPixelStorei (GL_UNPACK_SWAP_BYTES, GL_FALSE);
+  glPixelStorei (GL_UNPACK_LSB_FIRST, GL_FALSE);
+  glPixelStorei (GL_UNPACK_ROW_LENGTH, 0);
+
+  glPixelStorei (GL_UNPACK_SKIP_ROWS, 0);
+  glPixelStorei (GL_UNPACK_SKIP_PIXELS, 0);
+  glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
+
+  glReadBuffer(GL_FRONT);
+  glReadPixels (0, 0, (GLsizei)width, (GLsizei)height, format, GL_UNSIGNED_BYTE, (GLvoid*) buffer);
+
+  glPixelStorei (GL_UNPACK_SWAP_BYTES, swapbytes);
+  glPixelStorei (GL_UNPACK_LSB_FIRST, lsbfirst);
+  glPixelStorei (GL_UNPACK_ROW_LENGTH, rowlength);
+  
+  glPixelStorei (GL_UNPACK_SKIP_ROWS, skiprows);
+  glPixelStorei (GL_UNPACK_SKIP_PIXELS, skippixels);
+  glPixelStorei (GL_UNPACK_ALIGNMENT, alignment);
+  
+  return buffer;
+}
+
+bool G4OpenGLViewer::printEPS() {
+  bool res;
+
+  // Change the LC_NUMERIC value in order to have "." separtor and not ","
+  // This case is only useful for French, Canadien...
+  size_t len = strlen(setlocale(LC_NUMERIC,NULL));
+  char* oldLocale = (char*)(malloc(len+1));
+  if(oldLocale!=NULL) strncpy(oldLocale,setlocale(LC_NUMERIC,NULL),len);
+  setlocale(LC_NUMERIC,"C");
+
+  if (((fExportImageFormat == "eps") || (fExportImageFormat == "ps")) && (!fVectoredPs)) {
+    res = printNonVectoredEPS();
+  } else {
+    res = printVectoredEPS();
+  }
+
+  // restore the local
+  if (oldLocale) {
+    setlocale(LC_NUMERIC,oldLocale);
+    free(oldLocale);
+  }
+
+  if (res == false) {
+    G4cerr << "Error saving file... " << getRealPrintFilename().c_str() << G4endl;
+  } else {
+    G4cout << "File " << getRealPrintFilename().c_str() << " size: " << getRealExportWidth() << "x" << getRealExportHeight() << " has been saved " << G4endl;
+
+    // increment index if necessary
+    if ( fExportFilenameIndex != -1) {
+      fExportFilenameIndex++;
+    }
+  }
+
+  return res;
+}
+
+bool G4OpenGLViewer::printVectoredEPS() {
+  return printGl2PS();
+}
+
+bool G4OpenGLViewer::printNonVectoredEPS () {
+
+  int width = getRealExportWidth();
+  int height = getRealExportHeight();
+
+  FILE* fp;
+  GLubyte* pixels;
+  GLubyte* curpix;
+  int components, pos, i;
+
+  pixels = grabPixels (fPrintColour, width, height);
+
+  if (pixels == NULL) {
+      G4cerr << "Failed to get pixels from OpenGl viewport" << G4endl;
+    return false;
+  }
+  if (fPrintColour) {
+    components = 3;
+  } else {
+    components = 1;
+  }
+  std::string name = getRealPrintFilename();
+  fp = fopen (name.c_str(), "w");
+  if (fp == NULL) {
+    G4cerr << "Can't open filename " << name.c_str() << G4endl;
+    return false;
+  }
+  
+  fprintf (fp, "%%!PS-Adobe-2.0 EPSF-1.2\n");
+  fprintf (fp, "%%%%Title: %s\n", name.c_str());
+  fprintf (fp, "%%%%Creator: OpenGL pixmap render output\n");
+  fprintf (fp, "%%%%BoundingBox: 0 0 %d %d\n", width, height);
+  fprintf (fp, "%%%%EndComments\n");
+  fprintf (fp, "gsave\n");
+  fprintf (fp, "/bwproc {\n");
+  fprintf (fp, "    rgbproc\n");
+  fprintf (fp, "    dup length 3 idiv string 0 3 0 \n");
+  fprintf (fp, "    5 -1 roll {\n");
+  fprintf (fp, "    add 2 1 roll 1 sub dup 0 eq\n");
+  fprintf (fp, "    { pop 3 idiv 3 -1 roll dup 4 -1 roll dup\n");
+  fprintf (fp, "       3 1 roll 5 -1 roll } put 1 add 3 0 \n");
+  fprintf (fp, "    { 2 1 roll } ifelse\n");
+  fprintf (fp, "    }forall\n");
+  fprintf (fp, "    pop pop pop\n");
+  fprintf (fp, "} def\n");
+  fprintf (fp, "systemdict /colorimage known not {\n");
+  fprintf (fp, "   /colorimage {\n");
+  fprintf (fp, "       pop\n");
+  fprintf (fp, "       pop\n");
+  fprintf (fp, "       /rgbproc exch def\n");
+  fprintf (fp, "       { bwproc } image\n");
+  fprintf (fp, "   }  def\n");
+  fprintf (fp, "} if\n");
+  fprintf (fp, "/picstr %d string def\n", width * components);
+  fprintf (fp, "%d %d scale\n", width, height);
+  fprintf (fp, "%d %d %d\n", width, height, 8);
+  fprintf (fp, "[%d 0 0 %d 0 0]\n", width, height);
+  fprintf (fp, "{currentfile picstr readhexstring pop}\n");
+  fprintf (fp, "false %d\n", components);
+  fprintf (fp, "colorimage\n");
+  
+  curpix = (GLubyte*) pixels;
+  pos = 0;
+  for (i = width*height*components; i>0; i--) {
+    fprintf (fp, "%02hx ", (unsigned short)(*(curpix++)));
+    if (++pos >= 32) {
+      fprintf (fp, "\n");
+      pos = 0; 
+    }
+  }
+  if (pos)
+    fprintf (fp, "\n");
+
+  fprintf (fp, "grestore\n");
+  fprintf (fp, "showpage\n");
+  delete [] pixels;
+  fclose (fp);
+
+  // Reset for next time (useful is size change)
+  //  fPrintSizeX = -1;
+  //  fPrintSizeY = -1;
+
+  return true;
+}
+
+/** Return if gl2ps is currently writing
+ */
+bool G4OpenGLViewer::isGl2psWriting() {
+
+  if (!fGL2PSAction) return false;
+  if (fGL2PSAction->fileWritingEnabled()) {
+    return true;
+  }
+  return false;
+}
+
+
+G4bool G4OpenGLViewer::isFramebufferReady() {
+  bool check = false;
+#ifdef G4VIS_BUILD_OPENGLQT_DRIVER
+  check = true;
+#endif
+#ifdef G4VIS_BUILD_OPENGLX_DRIVER
+  check = false;
+#endif
+#ifdef G4VIS_BUILD_OPENGLXM_DRIVER
+  check = false;
+#endif
+#ifdef G4VIS_BUILD_OPENGLWIN32_DRIVER
+  check = false;
+#endif
+
+#if GL_ARB_framebuffer_object
+  if (check) {
+//    if ( glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_UNDEFINED) {
+//      return false;
+//    }
+  }
+#endif
+    return true;
+}
+
+
+/* Draw Gl2Ps text if needed
+ */
+void G4OpenGLViewer::DrawText(const G4Text& g4text)
+{
+  // gl2ps or GL window ?
+  if (isGl2psWriting()) {
+
+    G4VSceneHandler::MarkerSizeType sizeType;
+    G4double size = fSceneHandler.GetMarkerSize(g4text,sizeType);
+    G4Point3D position = g4text.GetPosition();
+
+    G4String textString = g4text.GetText();
+    
+    glRasterPos3d(position.x(),position.y(),position.z());
+    GLint align = GL2PS_TEXT_B;
+
+    switch (g4text.GetLayout()) {
+    case G4Text::left: align = GL2PS_TEXT_BL; break;
+    case G4Text::centre: align = GL2PS_TEXT_B; break;
+    case G4Text::right: align = GL2PS_TEXT_BR;
+    }
+    
+    gl2psTextOpt(textString.c_str(),"Times-Roman",GLshort(size),align,0);
+
+  } else {
+
+    static G4int callCount = 0;
+    ++callCount;
+    //if (callCount <= 10 || callCount%100 == 0) {
+    if (callCount <= 1) {
+      G4cout <<
+	"G4OpenGLViewer::DrawText: Not implemented for \""
+	     << fName <<
+	"\"\n  Called with "
+	     << g4text
+	     << G4endl;
+    }
+  }
+}
+
+/** Change PointSize on gl2ps if needed
+ */
+void G4OpenGLViewer::ChangePointSize(G4double size) {
+
+  if (isGl2psWriting()) {
+    fGL2PSAction->setPointSize(int(size));
+  } else {
+    glPointSize (size);
+  }
+}
+
+
+/** Change LineSize on gl2ps if needed
+ */
+void G4OpenGLViewer::ChangeLineWidth(G4double width) {
+
+  if (isGl2psWriting()) {
+    fGL2PSAction->setLineWidth(int(width));
+  } else {
+    glLineWidth (width);
+  }
+}
+
+/**
+ Export image with the given name with width and height
+ Several cases :
+ If name is "", filename will have the default value
+ If name is "toto.png", set the name to "toto" and the format to "png". No incremented suffix is added.
+ If name is "toto", set the name to "toto" and the format to default (or current format if specify).
+   Will also add an incremented suffix at the end of the file
+*/
+bool G4OpenGLViewer::exportImage(std::string name, int width, int height) {
+
+  if (! setExportFilename(name)) {
+    return false;
+  }
+
+  if ((width != -1) && (height != -1)) {
+    setExportSize(width, height);
+  }
+
+  if (fExportImageFormat == "eps") {
+    fGL2PSAction->setExportImageFormat(GL2PS_EPS);
+  } else if (fExportImageFormat == "ps") {
+    fGL2PSAction->setExportImageFormat(GL2PS_PS);
+  } else if (fExportImageFormat == "svg") {
+    fGL2PSAction->setExportImageFormat(GL2PS_SVG);
+  } else if (fExportImageFormat == "pdf") {
+    fGL2PSAction->setExportImageFormat(GL2PS_PDF);
+  } else {
+    setExportImageFormat(fExportImageFormat,true); // will display a message if this format is not correct for the current viewer
+    return false;
+  }
+  return printEPS();
+}
+
+
+bool G4OpenGLViewer::printGl2PS() {
+
+  int width = getRealExportWidth();
+  int height = getRealExportHeight();
+  bool res = true;
+
+  // no need to redraw at each new primitive for printgl2PS
+  G4OpenGLSceneHandler& oglSceneHandler = dynamic_cast<G4OpenGLSceneHandler&>(fSceneHandler);
+  G4OpenGLSceneHandler::FlushAction originalFlushAction = oglSceneHandler.GetFlushAction();
+  oglSceneHandler.SetFlushAction(G4OpenGLSceneHandler::never);
+
+  if (!fGL2PSAction) return false;
+
+  fGL2PSAction->setFileName(getRealPrintFilename().c_str());
+  // try to resize
+  int X = fWinSize_x;
+  int Y = fWinSize_y;
+
+  fWinSize_x = width;
+  fWinSize_y = height;
+  // Laurent G. 16/03/10 : Not the good way to do. 
+  // We should draw in a new offscreen context instead of
+  // resizing and drawing in current window...
+  // This should be solve when we will do an offscreen method
+  // to render OpenGL
+  // See : 
+  // http://developer.apple.com/Mac/library/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_offscreen/opengl_offscreen.html
+  // http://www.songho.ca/opengl/gl_fbo.html
+
+   ResizeGLView();
+   bool extendBuffer = true;
+   bool endWriteAction = false;
+   bool beginWriteAction = true;
+   bool filePointerOk = true;
+   while ((extendBuffer) && (! endWriteAction) && (filePointerOk)) {
+     
+     beginWriteAction = fGL2PSAction->enableFileWriting();
+     // 3 cases :
+     // - true
+     // - false && ! fGL2PSAction->fileWritingEnabled() => bad file name
+     // - false && fGL2PSAction->fileWritingEnabled() => buffer size problem ?
+
+     filePointerOk = fGL2PSAction->fileWritingEnabled();
+       
+     if (beginWriteAction) {
+       
+       // Set the viewport
+       // By default, we choose the line width (trajectories...)
+       fGL2PSAction->setLineWidth(fGl2psDefaultLineWith);
+       // By default, we choose the point size (markers...)
+       fGL2PSAction->setPointSize(fGl2psDefaultPointSize);
+       
+       DrawView ();
+       endWriteAction = fGL2PSAction->disableFileWriting();
+     }
+     if (filePointerOk) {
+       if ((! endWriteAction) || (! beginWriteAction)) {
+         extendBuffer = fGL2PSAction->extendBufferSize();
+       }
+     }
+   }
+   fGL2PSAction->resetBufferSizeParameters();
+
+   if (!extendBuffer ) {
+     G4cerr << "ERROR: gl2ps buffer size is not big enough to print this geometry. Try to extend it. No output produced"<< G4endl;
+     res = false;
+   }
+   if (!beginWriteAction ) {
+     G4cerr << "ERROR: saving file "<<getRealPrintFilename().c_str()<<". Check read/write access. No output produced" << G4endl;
+     res = false;
+   }
+   if (!endWriteAction ) {
+     G4cerr << "gl2ps error. No output produced" << G4endl;
+     res = false;
+   }
+  fWinSize_x = X;
+  fWinSize_y = Y;
+
+  oglSceneHandler.SetFlushAction(originalFlushAction);
+
+  // Reset for next time (useful is size change)
+  //  fPrintSizeX = 0;
+  //  fPrintSizeY = 0;
+
+  return res;
+}
+
+unsigned int G4OpenGLViewer::getWinWidth() const{
+  return fWinSize_x;
+}
+
+unsigned int G4OpenGLViewer::getWinHeight() const{
+  return fWinSize_y;
+}
+
+G4bool G4OpenGLViewer::sizeHasChanged() {
+  return fSizeHasChanged;
+}
+
+G4int G4OpenGLViewer::getRealExportWidth() {
+  if (fPrintSizeX == -1) {
+    return fWinSize_x;
+  }
+  GLint dims[2];
+  glGetIntegerv(GL_MAX_VIEWPORT_DIMS, dims);
+
+  // L.Garnier 01-2010: Some problems with mac 10.6
+  if ((dims[0] !=0 ) && (dims[1] !=0)) {
+    if (fPrintSizeX > dims[0]){
+      return dims[0];
+    }
+  }
+  if (fPrintSizeX < -1){
+    return 0;
+  }
+  return fPrintSizeX;
+}
+
+G4int G4OpenGLViewer::getRealExportHeight() {
+  if (fPrintSizeY == -1) {
+    return fWinSize_y;
+  }
+  GLint dims[2];
+  glGetIntegerv(GL_MAX_VIEWPORT_DIMS, dims);
+
+  // L.Garnier 01-2010: Some problems with mac 10.6
+  if ((dims[0] !=0 ) && (dims[1] !=0)) {
+    if (fPrintSizeY > dims[1]){
+      return dims[1];
+    }
+  }
+  if (fPrintSizeY < -1){
+    return 0;
+  }
+  return fPrintSizeY;
+}
+
+void G4OpenGLViewer::setExportSize(G4int X, G4int Y) {
+  fPrintSizeX = X;
+  fPrintSizeY = Y;
+}
+
+/**
+ If name is "" or "!", filename and extension will have the default value.
+ If name is "toto.png", set the name to "toto" and the format to "png". No incremented suffix is added.
+ If name is "toto", set the name to "toto" and the format to default (or current format if specify).
+ If name is the same as previous, do not reset incremented suffix.
+*/
+bool G4OpenGLViewer::setExportFilename(G4String name,G4bool inc) {
+  if (name == "!") {
+    name = "";
+  }
+
+  if (inc) {
+    if ((name != "") && (fExportFilename != name)) {
+      fExportFilenameIndex=0;
+    }
+  } else {
+    fExportFilenameIndex=-1;
+  }
+
+  if (name.size() == 0) {
+    name = getRealPrintFilename().c_str();
+  } else {
+    // guess format by extention
+    std::string extension = name.substr(name.find_last_of(".") + 1);
+    // no format
+    if (name.size() != extension.size()) {
+      if (! setExportImageFormat(extension, false)) {
+        return false;
+      }
+    }
+    // get the name
+    fExportFilename = name.substr(0,name.find_last_of("."));
+  }
+  return true;
+}
+
+std::string G4OpenGLViewer::getRealPrintFilename() {
+  std::string temp = fExportFilename;
+  if (fExportFilenameIndex != -1) {
+    temp += std::string("_");
+    std::ostringstream os;
+    os << std::setw(4) << std::setfill('0') << fExportFilenameIndex;
+    std::string nb_str = os.str();
+    temp += nb_str;
+  }
+  temp += "."+fExportImageFormat;
+  return temp;
+}
+
+GLdouble G4OpenGLViewer::getSceneNearWidth()
+{
+  if (!fSceneHandler.GetScene()) {
+    return 0;
+  }
+  const G4Point3D targetPoint
+    = fSceneHandler.GetScene()->GetStandardTargetPoint()
+    + fVP.GetCurrentTargetPoint ();
+  G4double radius = fSceneHandler.GetScene()->GetExtent().GetExtentRadius();
+  if(radius<=0.) radius = 1.;
+  const G4double cameraDistance = fVP.GetCameraDistance (radius);
+  const GLdouble pnear   = fVP.GetNearDistance (cameraDistance, radius);
+  return 2 * fVP.GetFrontHalfHeight (pnear, radius);
+}
+
+GLdouble G4OpenGLViewer::getSceneFarWidth()
+{
+  if (!fSceneHandler.GetScene()) {
+    return 0;
+  }
+  const G4Point3D targetPoint
+    = fSceneHandler.GetScene()->GetStandardTargetPoint()
+    + fVP.GetCurrentTargetPoint ();
+  G4double radius = fSceneHandler.GetScene()->GetExtent().GetExtentRadius();
+  if(radius<=0.) radius = 1.;
+  const G4double cameraDistance = fVP.GetCameraDistance (radius);
+  const GLdouble pnear   = fVP.GetNearDistance (cameraDistance, radius);
+  const GLdouble pfar    = fVP.GetFarDistance  (cameraDistance, pnear, radius);
+  return 2 * fVP.GetFrontHalfHeight (pfar, radius);
+}
+
+
+GLdouble G4OpenGLViewer::getSceneDepth()
+{
+  if (!fSceneHandler.GetScene()) {
+    return 0;
+  }
+  const G4Point3D targetPoint
+    = fSceneHandler.GetScene()->GetStandardTargetPoint()
+    + fVP.GetCurrentTargetPoint ();
+  G4double radius = fSceneHandler.GetScene()->GetExtent().GetExtentRadius();
+  if(radius<=0.) radius = 1.;
+  const G4double cameraDistance = fVP.GetCameraDistance (radius);
+  const GLdouble pnear   = fVP.GetNearDistance (cameraDistance, radius);
+  return fVP.GetFarDistance  (cameraDistance, pnear, radius)- pnear;
+}
+
+
+
+void G4OpenGLViewer::rotateScene(G4double dx, G4double dy)
+{
+  if (fVP.GetRotationStyle() == G4ViewParameters::freeRotation) {
+    rotateSceneInViewDirection(dx,dy);
+  } else {
+    if( dx != 0) {
+      rotateSceneThetaPhi(dx,0);
+    }
+    if( dy != 0) {
+      rotateSceneThetaPhi(0,dy);
+    }
+  }
+}
+
+
+void G4OpenGLViewer::rotateSceneToggle(G4double dx, G4double dy)
+{
+  if (fVP.GetRotationStyle() != G4ViewParameters::freeRotation) {
+    rotateSceneInViewDirection(dx,dy);
+  } else {
+    if( dx != 0) {
+      rotateSceneThetaPhi(dx,0);
+    }
+    if( dy != 0) {
+      rotateSceneThetaPhi(0,dy);
+    }
+  }
+}
+
+void G4OpenGLViewer::rotateSceneThetaPhi(G4double dx, G4double dy)
+{
+  if (!fSceneHandler.GetScene()) {
+    return;
+  }
+
+  G4Vector3D vp;
+  G4Vector3D up;
+  
+  G4Vector3D xprime;
+  G4Vector3D yprime;
+  G4Vector3D zprime;
+  
+  G4double delta_alpha;
+  G4double delta_theta;
+  
+  G4Vector3D new_vp;
+  G4Vector3D new_up;
+  
+  G4double cosalpha;
+  G4double sinalpha;
+  
+  G4Vector3D a1;
+  G4Vector3D a2;
+  G4Vector3D delta;
+  G4Vector3D viewPoint;
+
+    
+  //phi spin stuff here
+  
+  vp = fVP.GetViewpointDirection ().unit ();
+  up = fVP.GetUpVector ().unit ();
+  
+  yprime = (up.cross(vp)).unit();
+  zprime = (vp.cross(yprime)).unit();
+  
+  if (fVP.GetLightsMoveWithCamera()) {
+    delta_alpha = dy * fRot_sens;
+    delta_theta = -dx * fRot_sens;
+  } else {
+    delta_alpha = -dy * fRot_sens;
+    delta_theta = dx * fRot_sens;
+  }    
+  
+  delta_alpha *= deg;
+  delta_theta *= deg;
+  
+  new_vp = std::cos(delta_alpha) * vp + std::sin(delta_alpha) * zprime;
+  
+  // to avoid z rotation flipping
+  // to allow more than 360∞ rotation
+
+  if (fVP.GetLightsMoveWithCamera()) {
+    new_up = (new_vp.cross(yprime)).unit();
+    if (new_vp.z()*vp.z() <0) {
+      new_up.set(new_up.x(),-new_up.y(),new_up.z());
+    }
+  } else {
+    new_up = up;
+    if (new_vp.z()*vp.z() <0) {
+      new_up.set(new_up.x(),-new_up.y(),new_up.z());
+    }
+  }
+  fVP.SetUpVector(new_up);
+  ////////////////
+  // Rotates by fixed azimuthal angle delta_theta.
+  
+  cosalpha = new_up.dot (new_vp.unit());
+  sinalpha = std::sqrt (1. - std::pow (cosalpha, 2));
+  yprime = (new_up.cross (new_vp.unit())).unit ();
+  xprime = yprime.cross (new_up);
+  // Projection of vp on plane perpendicular to up...
+  a1 = sinalpha * xprime;
+  // Required new projection...
+  a2 = sinalpha * (std::cos (delta_theta) * xprime + std::sin (delta_theta) * yprime);
+  // Required Increment vector...
+  delta = a2 - a1;
+  // So new viewpoint is...
+  viewPoint = new_vp.unit() + delta;
+  
+  fVP.SetViewAndLights (viewPoint);
+}
+
+
+void G4OpenGLViewer::rotateSceneInViewDirection(G4double dx, G4double dy)
+{
+  if (!fSceneHandler.GetScene()) {
+    return;
+  }
+
+  G4Vector3D vp;
+  G4Vector3D up;
+  
+  G4Vector3D xprime;
+  G4Vector3D yprime;
+  G4Vector3D zprime;
+  
+  G4Vector3D new_vp;
+  G4Vector3D new_up;
+  
+  G4Vector3D a1;
+  G4Vector3D a2;
+  G4Vector3D delta;
+  G4Vector3D viewPoint;
+
+  dx = dx/100;
+  dy = dy/100;
+
+  //phi spin stuff here
+  
+  vp = fVP.GetViewpointDirection ().unit();
+  up = fVP.GetUpVector ().unit();
+
+  G4Vector3D zPrimeVector = G4Vector3D(up.y()*vp.z()-up.z()*vp.y(),
+                             up.z()*vp.x()-up.x()*vp.z(),
+                             up.x()*vp.y()-up.y()*vp.x());
+
+  viewPoint = vp/fRot_sens + (zPrimeVector*dx - up*dy) ;
+  new_up = G4Vector3D(viewPoint.y()*zPrimeVector.z()-viewPoint.z()*zPrimeVector.y(),
+                       viewPoint.z()*zPrimeVector.x()-viewPoint.x()*zPrimeVector.z(),
+                       viewPoint.x()*zPrimeVector.y()-viewPoint.y()*zPrimeVector.x());
+
+  G4Vector3D new_upUnit = new_up.unit();
+  
+  
+
+   fVP.SetUpVector(new_upUnit);
+   fVP.SetViewAndLights (viewPoint);
+}
+
+
+void G4OpenGLViewer::addExportImageFormat(std::string format) {
+  fExportImageFormatVector.push_back(format);
+}
+
+bool G4OpenGLViewer::setExportImageFormat(std::string format, bool quiet) {
+  bool found = false;
+  std::string list;
+  for (unsigned int a=0; a<fExportImageFormatVector.size(); a++) {
+    list +=fExportImageFormatVector.at(a) + " ";
+
+    if (fExportImageFormatVector.at(a) == format) {
+      if (! quiet) {
+        G4cout << " Changing export format to \"" << format << "\"" << G4endl;
+      }
+      if (format != fExportImageFormat) {
+        fExportFilenameIndex = 0;
+        fExportImageFormat = format;
+      }
+      return true;
+    }
+  }
+  if (! found) {
+    if (format.size() == 0) {
+      G4cout << " Current formats availables are : " << list << G4endl;
+    } else {
+      G4cerr << " Format \"" << format << "\" is not available for the selected viewer. Current formats availables are : " << list << G4endl;
+    }
+  }
+  return false;
+}
+
+
+// From MESA implementation :
+// http://www.techques.com/question/1-8660454/gluPickMatrix-code-from-Mesa
+
+void G4OpenGLViewer::g4GluPickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
+                     GLint viewport[4])
+  {
+    GLdouble mat[16];
+    GLdouble sx, sy;
+    GLdouble tx, ty;
+    
+    sx = viewport[2] / width;
+    sy = viewport[3] / height;
+    tx = (viewport[2] + 2.0 * (viewport[0] - x)) / width;
+    ty = (viewport[3] + 2.0 * (viewport[1] - y)) / height;
+    
+#define M(row, col) mat[col*4+row]
+    M(0, 0) = sx;
+    M(0, 1) = 0.0;
+    M(0, 2) = 0.0;
+    M(0, 3) = tx;
+    M(1, 0) = 0.0;
+    M(1, 1) = sy;
+    M(1, 2) = 0.0;
+    M(1, 3) = ty;
+    M(2, 0) = 0.0;
+    M(2, 1) = 0.0;
+    M(2, 2) = 1.0;
+    M(2, 3) = 0.0;
+    M(3, 0) = 0.0;
+    M(3, 1) = 0.0;
+    M(3, 2) = 0.0;
+    M(3, 3) = 1.0;
+#undef M
+    
+    glMultMatrixd(mat);
+}
+
+
+
+
+
+// From MESA implementation :
+// https://github.com/jlamarche/iOS-OpenGLES-Stuff/blob/master/Wavefront%20OBJ%20Loader/Classes/gluLookAt.m
+// or http://www.daniweb.com/software-development/game-development/threads/308901/lookat-matrix-source-code
+
+void G4OpenGLViewer::g4GluLookAt( GLdouble eyex, GLdouble eyey, GLdouble eyez,
+                        GLdouble centerx, GLdouble centery, GLdouble
+                        centerz,
+                        GLdouble upx, GLdouble upy, GLdouble upz )
+{
+	GLdouble mat[16];
+	GLdouble x[3], y[3], z[3];
+	GLdouble mag;
+  
+	/* Make rotation matrix */
+  
+	/* Z vector */
+	z[0] = eyex - centerx;
+	z[1] = eyey - centery;
+	z[2] = eyez - centerz;
+	mag = std::sqrt(z[0] * z[0] + z[1] * z[1] + z[2] * z[2]);
+	if (mag) {			/* mpichler, 19950515 */
+		z[0] /= mag;
+		z[1] /= mag;
+		z[2] /= mag;
+	}
+  
+	/* Y vector */
+	y[0] = upx;
+	y[1] = upy;
+	y[2] = upz;
+  
+	/* X vector = Y cross Z */
+	x[0] = y[1] * z[2] - y[2] * z[1];
+	x[1] = -y[0] * z[2] + y[2] * z[0];
+	x[2] = y[0] * z[1] - y[1] * z[0];
+  
+	/* Recompute Y = Z cross X */
+	y[0] = z[1] * x[2] - z[2] * x[1];
+	y[1] = -z[0] * x[2] + z[2] * x[0];
+	y[2] = z[0] * x[1] - z[1] * x[0];
+  
+	/* mpichler, 19950515 */
+	/* cross product gives area of parallelogram, which is < 1.0 for
+	 * non-perpendicular unit-length vectors; so normalize x, y here
+	 */
+  
+	mag = std::sqrt(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]);
+	if (mag) {
+		x[0] /= mag;
+		x[1] /= mag;
+		x[2] /= mag;
+	}
+  
+	mag = std::sqrt(y[0] * y[0] + y[1] * y[1] + y[2] * y[2]);
+	if (mag) {
+		y[0] /= mag;
+		y[1] /= mag;
+		y[2] /= mag;
+	}
+  
+#define M(row,col)  mat[col*4+row]
+	M(0, 0) = x[0];
+	M(0, 1) = x[1];
+	M(0, 2) = x[2];
+	M(0, 3) = 0.0;
+	M(1, 0) = y[0];
+	M(1, 1) = y[1];
+	M(1, 2) = y[2];
+	M(1, 3) = 0.0;
+	M(2, 0) = z[0];
+	M(2, 1) = z[1];
+	M(2, 2) = z[2];
+	M(2, 3) = 0.0;
+	M(3, 0) = 0.0;
+	M(3, 1) = 0.0;
+	M(3, 2) = 0.0;
+	M(3, 3) = 1.0;
+#undef M
+	glMultMatrixd(mat);
+  
+	/* Translate Eye to Origin */
+	glTranslated(-eyex, -eyey, -eyez);
+}
+
+void G4OpenGLViewer::g4GlOrtho (GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble zNear, GLdouble zFar) {
+  //  glOrtho (left, right, bottom, top, near, far);
+  
+  GLdouble a = 2.0 / (right - left);
+  GLdouble b = 2.0 / (top - bottom);
+  GLdouble c = -2.0 / (zFar - zNear);
+  
+  GLdouble tx = - (right + left)/(right - left);
+  GLdouble ty = - (top + bottom)/(top - bottom);
+  GLdouble tz = - (zFar + zNear)/(zFar - zNear);
+  
+  GLdouble ortho[16] = {
+    a, 0, 0, 0,
+    0, b, 0, 0,
+    0, 0, c, 0,
+    tx, ty, tz, 1
+  };
+  glMultMatrixd(ortho);
+  
+}
+
+
+void G4OpenGLViewer::g4GlFrustum (GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble zNear, GLdouble zFar) {
+  //  glFrustum (left, right, bottom, top, near, far);
+  
+  GLdouble deltaX = right - left;
+  GLdouble deltaY = top - bottom;
+  GLdouble deltaZ = zFar - zNear;
+  
+  GLdouble a = 2.0f * zNear / deltaX;
+  GLdouble b = 2.0f * zNear / deltaY;
+  GLdouble c = (right + left) / deltaX;
+  GLdouble d = (top + bottom) / deltaY;
+  GLdouble e = -(zFar + zNear) / (zFar - zNear);
+  GLdouble f = -2.0f * zFar * zNear / deltaZ;
+  
+  GLdouble proj[16] = {
+    a, 0, 0, 0,
+    0, b, 0, 0,
+    c, d, e, -1.0f,
+    0, 0, f, 0
+  };
+  
+  glMultMatrixd(proj);
+  
+}
+
+
+#ifdef G4OPENGL_VERSION_2
+
+// Associate the VBO drawer to the OpenGLViewer and the OpenGLSceneHandler
+void G4OpenGLViewer::setVboDrawer(G4OpenGLVboDrawer* drawer) {
+  fVboDrawer = drawer;
+  try {
+    G4OpenGLSceneHandler& sh = dynamic_cast<G4OpenGLSceneHandler&>(fSceneHandler);
+    sh.setVboDrawer(fVboDrawer);
+  } catch(std::bad_cast exp) { }
+}
+
+#endif
+
+
+G4String G4OpenGLViewerPickMap::print() {
+  std::ostringstream txt;
+
+#ifdef LAYERED_GEOMETRY_PICKING_EXTENSIONS
+  G4TransportationManager *tmanager =
+                      G4TransportationManager::GetTransportationManager();
+  std::vector<G4VPhysicalVolume*>::iterator iter = 
+                                            tmanager->GetWorldsIterator();
+  G4FieldManager *fieldmgr = 0;
+  bool warning = false;
+  bool seen = false;
+  for (int world = tmanager->GetNoWorlds() - 1; world >= 0; --world) {
+    G4Navigator *navigator = tmanager->GetNavigator(iter[world]);
+    G4VPhysicalVolume *pvol = navigator->
+                              LocateGlobalPointAndSetup(fCoordinates,0,false);
+    if (!pvol)
+      continue;
+    G4LogicalVolume *lvol = pvol->GetLogicalVolume();
+    if (!lvol)
+      continue;
+    G4Material *mat = lvol->GetMaterial();
+    if (fieldmgr == 0) {
+      fieldmgr = lvol->GetFieldManager();
+    }
+    else if (fieldmgr != lvol->GetFieldManager()) {
+      txt << "ERROR - field manager inconsistency found in world " << world
+          << std::endl;
+      warning = true;
+    }
+    if (warning || (mat != 0 && !seen)) {
+      G4TouchableHistory *hist = navigator->CreateTouchableHistory();
+      std::ostringstream pvpath;
+      pvpath << "/" << navigator->GetWorldVolume()->GetName() << ":0";
+      for (int depth = hist->GetHistoryDepth() - 1; depth >= 0; --depth) {
+        pvpath << "/" << hist->GetVolume(depth)->GetName()
+               << ":" << hist->GetVolume(depth)->GetCopyNo();
+      }
+   
+      txt << "(" << fCoordinates[0] / cm 
+          << "," << fCoordinates[1] / cm
+          << "," << fCoordinates[2] / cm << ")"
+          << " found in " << pvol->GetName() << " copy " << pvol->GetCopyNo()
+          << " of " << lvol->GetName() << " with " << std::endl
+          << "   complete path: " << pvpath.str() << std::endl
+          << "   layer " << world << " material: " 
+          << ((mat)? mat->GetName() : "0") << std::endl;
+      if (fieldmgr) {
+        const G4Field *fld = fieldmgr->GetDetectorField();
+        if (fld) {
+          double Bfld[3];
+          double xglob[4] = {fCoordinates[0],fCoordinates[1],fCoordinates[2],0};
+          fld->GetFieldValue(xglob,Bfld);
+          txt << "   magnetic field (Tesla): "
+              << Bfld[0] / tesla << "," 
+              << Bfld[1] / tesla << "," 
+              << Bfld[2] / tesla << std::endl;
+        }
+        else {
+          txt << "   magnetic field: UNDEFINED" << std::endl;
+        }
+      }
+      else {
+        txt << "   magnetic field: null" << std::endl;
+      }
+      seen = true;
+    }
+  }
+
+#else
+  txt << fName;
+
+  txt << "Hit: " << fHitNumber << ", Sub-hit: " << fSubHitNumber << ", PickName: " << fPickName << "\n";
+  
+  for (unsigned int a=0; a<fAttributes.size(); a++) {
+    txt << fAttributes[a] << "\n";
+  }
+#endif
+  return txt.str();
+}
+
+#endif

--- a/src/G4.10.03.p01fixes/G4OpenGLViewer.hh
+++ b/src/G4.10.03.p01fixes/G4OpenGLViewer.hh
@@ -1,0 +1,341 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4OpenGLViewer.hh 101714 2016-11-22 08:53:13Z gcosmo $
+//
+// 
+// Andrew Walkden  27th March 1996
+// OpenGL viewer - opens window, hard copy, etc.
+
+#ifdef G4VIS_BUILD_OPENGL_DRIVER
+
+#ifndef G4OPENGLVIEWER_HH
+#define G4OPENGLVIEWER_HH
+
+#include "G4VViewer.hh"
+#include "G4OpenGL.hh"
+#ifdef G4OPENGL_VERSION_2
+#include "G4OpenGLVboDrawer.hh"
+#endif
+
+class G4OpenGLSceneHandler;
+class G4OpenGL2PSAction;
+class G4Text;
+
+class G4OpenGLViewerPickMap {
+  public :
+  inline void setName(G4String n) {
+    fName = n;
+  }
+  
+  inline void setHitNumber(G4int n) {
+    fHitNumber = n;
+  }
+
+  inline void setSubHitNumber(G4int n) {
+    fSubHitNumber = n;
+  }
+  inline void setPickName(G4int n) {
+    fPickName= n;
+  }
+
+  inline void addAttributes(G4String att) {
+    fAttributes.push_back(att);
+  }
+
+#ifdef LAYERED_GEOMETRY_PICKING_EXTENSIONS
+  inline void setPickCoordinates3D(const G4ThreeVector &v) {
+    fCoordinates = v;
+  }
+  inline G4ThreeVector getPickCoordinates3D() {
+    return fCoordinates;
+  }
+#endif
+
+
+  inline G4String getName() {
+    return fName;
+  }
+  inline G4int getHitNumber() {
+    return fHitNumber;
+  }
+
+  inline G4int getSubHitNumber() {
+    return fSubHitNumber;
+  }
+
+  inline G4int getPickName() {
+    return fPickName;
+  }
+
+  inline std::vector <G4String > getAttributes() {
+    return fAttributes;
+  }
+
+  G4String print();
+  
+  private :
+  G4String fName;
+  G4int fHitNumber;
+  G4int fSubHitNumber;
+  G4int fPickName;
+  std::vector <G4String > fAttributes;
+#ifdef LAYERED_GEOMETRY_PICKING_EXTENSIONS
+  G4ThreeVector fCoordinates;
+#endif
+
+};
+
+// Base class for various OpenGLView classes.
+class G4OpenGLViewer: virtual public G4VViewer {
+
+  friend class G4OpenGLSceneHandler;
+  friend class G4OpenGLImmediateSceneHandler;
+  friend class G4OpenGLStoredSceneHandler;
+  friend class G4OpenGLFileSceneHandler;
+  friend class G4OpenGLViewerMessenger;
+
+public:
+  void ClearView  ();
+  void ClearViewWithoutFlush ();
+//////////////////////////////Vectored PostScript production functions///
+  bool printEPS();
+  virtual bool exportImage(std::string name="", int width=-1, int height=-1);
+
+  bool setExportImageFormat(std::string format,bool quiet = false);
+  // change the export image format according to thoses available for the current viewer
+
+  // Special case for Wt, we want to have acces to the drawer
+#ifdef G4OPENGL_VERSION_2
+  inline G4OpenGLVboDrawer* getWtDrawer() {return fVboDrawer;}
+  
+  // Associate the Wt drawer to the OpenGLViewer and the OpenGLSceneHandler
+  void setVboDrawer(G4OpenGLVboDrawer* drawer);
+  G4OpenGLVboDrawer* fVboDrawer;
+
+  inline bool isInitialized() {
+    return fGlViewInitialized;
+  }
+#endif
+
+protected:
+  G4OpenGLViewer (G4OpenGLSceneHandler& scene);
+  virtual ~G4OpenGLViewer ();
+
+private:
+  G4OpenGLViewer(const G4OpenGLViewer&);
+  G4OpenGLViewer& operator= (const G4OpenGLViewer&);
+
+protected:
+  void SetView    ();
+  void ResetView ();
+
+  virtual void DrawText(const G4Text&);
+  void ChangePointSize(G4double size);
+  void ChangeLineWidth(G4double width);
+  void HaloingFirstPass ();
+  void HaloingSecondPass ();
+  void HLRFirstPass ();
+  void HLRSecondPass ();
+  void HLRThirdPass ();
+  void InitializeGLView ();
+  void ResizeGLView();
+  void ResizeWindow(unsigned int, unsigned int);
+  virtual G4String Pick(GLdouble x, GLdouble y);
+  std::vector < G4OpenGLViewerPickMap* > GetPickDetails(GLdouble x, GLdouble y);
+  virtual void CreateFontLists () {}
+  void rotateScene (G4double dx, G4double dy);
+  void rotateSceneToggle (G4double dx, G4double dy);
+//////////////////////////////Vectored PostScript production functions///
+  // print EPS file. Depending of fVectoredPs, it will print Vectored or not
+  void setExportSize(G4int,G4int);
+  // set the new print size. 
+  // -1 means 'print size' = 'window size'
+  // Setting size greater than max OpenGL viewport size will set the size to
+  // maximum
+  bool setExportFilename(G4String name,G4bool inc = true);
+  // set export filename.
+  // if inc, then the filename will be increment by one each time
+  // try to guesss the correct format according to the extention
+
+  std::string getRealPrintFilename();
+  unsigned int getWinWidth() const;
+  unsigned int getWinHeight() const;
+  G4bool sizeHasChanged();
+  // return true if size has change since last redraw
+  GLdouble getSceneNearWidth();
+  GLdouble getSceneFarWidth();
+  GLdouble getSceneDepth();
+  void addExportImageFormat(std::string format);
+  // add a image format to the available export format list
+  G4bool isGl2psWriting();
+  G4bool isFramebufferReady();
+  
+  void g4GluPickMatrix(GLdouble x, GLdouble y, GLdouble width, GLdouble height,
+                       GLint viewport[4]);
+  // MESA implementation of gluPickMatrix
+  
+  void g4GluLookAt( GLdouble eyex, GLdouble eyey, GLdouble eyez,
+                   GLdouble centerx, GLdouble centery, GLdouble
+                   centerz,
+                   GLdouble upx, GLdouble upy, GLdouble upz );
+  // MESA implementation of gluLookAt
+  void g4GlOrtho (GLdouble left, GLdouble right,
+                  GLdouble bottom, GLdouble top,
+                  GLdouble near, GLdouble far);
+  // Redefinition on glOrtho to solve precision issues
+  void g4GlFrustum (GLdouble left, GLdouble right,
+                  GLdouble bottom, GLdouble top,
+                  GLdouble near, GLdouble far);
+  // Redefinition on glFrustum to solve precision issues
+
+  G4bool                            fPrintColour;
+  G4bool                            fVectoredPs;
+
+  G4OpenGLSceneHandler& fOpenGLSceneHandler;
+  G4Colour background;      //the OpenGL clear colour
+  G4bool
+    transparency_enabled,   //is alpha blending enabled?
+    antialiasing_enabled,   //is antialiasing enabled?
+    haloing_enabled;        //is haloing enabled for wireframe?
+  G4double fStartTime, fEndTime;  // Time range (e.g., for trajectory steps).
+  G4double fFadeFactor;  // 0: no fade; 1: maximum fade with time within range.
+  G4bool fDisplayHeadTime;  // Display head time (fEndTime) in 2D text.
+  G4double fDisplayHeadTimeX, fDisplayHeadTimeY;  // 2D screen coords.
+  G4double fDisplayHeadTimeSize;  // Screen size.
+  G4double fDisplayHeadTimeRed, fDisplayHeadTimeGreen, fDisplayHeadTimeBlue;
+  G4bool fDisplayLightFront;// Display light front at head time originating at
+  G4double fDisplayLightFrontX, fDisplayLightFrontY, fDisplayLightFrontZ,
+    fDisplayLightFrontT;
+  G4double fDisplayLightFrontRed, fDisplayLightFrontGreen, fDisplayLightFrontBlue;
+  G4OpenGL2PSAction* fGL2PSAction;
+
+  G4double     fRot_sens;        // Rotation sensibility in degrees
+  G4double     fPan_sens;        // Translation sensibility
+  unsigned int fWinSize_x;
+  unsigned int fWinSize_y;
+  std::vector < std::string > fExportImageFormatVector;
+  std::string fDefaultExportImageFormat;
+  std::string fExportImageFormat;
+  int fExportFilenameIndex;
+  G4int fPrintSizeX;
+  G4int fPrintSizeY;
+
+
+private :
+  G4float fPointSize;
+  G4String fExportFilename;
+  G4String fDefaultExportFilename;
+  G4bool fSizeHasChanged;
+  int fGl2psDefaultLineWith;
+  int fGl2psDefaultPointSize;
+  bool fGlViewInitialized;
+  
+  // size of the OpenGL frame
+  void rotateSceneThetaPhi(G4double dx, G4double dy);
+  void rotateSceneInViewDirection (G4double dx, G4double dy);
+  bool printGl2PS();
+  G4int getRealExportWidth();
+  G4int getRealExportHeight();
+  GLubyte* grabPixels (int inColor,
+		       unsigned int width,
+		       unsigned int height);
+  bool printNonVectoredEPS ();
+  // print non vectored EPS files
+
+  bool printVectoredEPS();
+  // print vectored EPS files
+  
+  bool fIsGettingPickInfos;
+  // Block SetView() during picking
+  
+#ifdef G4OPENGL_VERSION_2
+public:
+#ifdef G4VIS_BUILD_OPENGLWT_DRIVER
+  inline Wt::WGLWidget::Program getShaderProgram() {
+    return fShaderProgram;
+  }
+  inline Wt::WGLWidget::UniformLocation getShaderProjectionMatrix() {
+    return fpMatrixUniform;
+  }
+  inline Wt::WGLWidget::UniformLocation getShaderTransformMatrix() {
+    return ftMatrixUniform;
+  }
+#else
+  inline GLuint getShaderProgram() {
+    return fShaderProgram;
+  }
+  inline GLuint getShaderProjectionMatrix() {
+    return fpMatrixUniform;
+  }
+  inline GLuint getShaderTransformMatrix() {
+    return ftMatrixUniform;
+  }
+  inline GLuint getShaderViewModelMatrix() {
+    return fmvMatrixUniform;
+  }
+#endif
+
+protected :
+  
+  // define the keyword shader to handle it in a better way for OpenGL and WebGL
+#ifdef G4VIS_BUILD_OPENGLWT_DRIVER
+#define Shader Wt::WGLWidget::Shader
+#else
+#define Shader GLuint
+#endif
+  
+  // define some attributes and variables for OpenGL and WebGL
+#ifdef G4VIS_BUILD_OPENGLWT_DRIVER
+  Wt::WGLWidget::Program fShaderProgram;
+  
+  // Program and related variables
+  Wt::WGLWidget::AttribLocation fVertexPositionAttribute;
+  Wt::WGLWidget::AttribLocation fVertexNormalAttribute;
+  Wt::WGLWidget::UniformLocation fpMatrixUniform;
+  Wt::WGLWidget::UniformLocation fcMatrixUniform;
+  Wt::WGLWidget::UniformLocation fmvMatrixUniform;
+  Wt::WGLWidget::UniformLocation fnMatrixUniform;
+  Wt::WGLWidget::UniformLocation ftMatrixUniform;
+#else
+  GLuint fShaderProgram;
+  
+  // Program and related variables
+  GLuint fVertexPositionAttribute;
+  GLuint fVertexNormalAttribute;
+  GLuint fpMatrixUniform;
+  GLuint fcMatrixUniform;
+  GLuint fmvMatrixUniform;
+  GLuint fnMatrixUniform;
+  GLuint ftMatrixUniform;
+#endif
+  
+#endif
+};
+
+#endif
+
+#endif

--- a/src/G4.10.03.p01fixes/G4PhysicalVolumeModel.cc
+++ b/src/G4.10.03.p01fixes/G4PhysicalVolumeModel.cc
@@ -1,0 +1,1059 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4PhysicalVolumeModel.cc 101035 2016-11-04 08:48:17Z gcosmo $
+//
+// 
+// John Allison  31st December 1997.
+// Model for physical volumes.
+
+#include "G4PhysicalVolumeModel.hh"
+
+#include "G4ModelingParameters.hh"
+#include "G4VGraphicsScene.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4VPVParameterisation.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VSolid.hh"
+#include "G4SubtractionSolid.hh"
+#include "G4IntersectionSolid.hh"
+#include "G4Material.hh"
+#include "G4VisAttributes.hh"
+#include "G4BoundingSphereScene.hh"
+#include "G4PhysicalVolumeSearchScene.hh"
+#include "G4TransportationManager.hh"
+#include "G4Polyhedron.hh"
+#include "HepPolyhedronProcessor.h"
+#include "G4AttDefStore.hh"
+#include "G4AttDef.hh"
+#include "G4AttValue.hh"
+#include "G4UnitsTable.hh"
+#include "G4Vector3D.hh"
+
+#include <sstream>
+
+G4PhysicalVolumeModel::G4PhysicalVolumeModel
+(G4VPhysicalVolume*          pVPV
+ , G4int                       requestedDepth
+ , const G4Transform3D& modelTransformation
+ , const G4ModelingParameters* pMP
+ , G4bool useFullExtent)
+: G4VModel           (modelTransformation, pMP)
+, fpTopPV            (pVPV)
+, fTopPVCopyNo       (0)
+, fRequestedDepth    (requestedDepth)
+, fUseFullExtent     (useFullExtent)
+, fCurrentDepth      (0)
+, fpCurrentPV        (0)
+, fpCurrentLV        (0)
+, fpCurrentMaterial  (0)
+, fpCurrentTransform (0)
+, fAbort             (false)
+, fCurtailDescent    (false)
+, fpClippingSolid    (0)
+, fClippingMode      (subtraction)
+{
+  fType = "G4PhysicalVolumeModel";
+
+  if (!fpTopPV) {
+
+    // In some circumstances creating an "empty" G4PhysicalVolumeModel is
+    // allowed, so I have supressed the G4Exception below.  If it proves to
+    // be a problem we might have to re-instate it, but it is unlikley to
+    // be used except by visualisation experts.  See, for example, /vis/list,
+    // where it is used simply to get a list of G4AttDefs.
+    //    G4Exception
+    //    ("G4PhysicalVolumeModel::G4PhysicalVolumeModel",
+    //     "modeling0010", FatalException, "Null G4PhysicalVolumeModel pointer.");
+
+    fTopPVName = "NULL";
+    fGlobalTag = "Empty";
+    fGlobalDescription = "G4PhysicalVolumeModel " + fGlobalTag;
+
+  } else {
+
+    fTopPVName = fpTopPV -> GetName ();
+    fTopPVCopyNo = fpTopPV -> GetCopyNo ();
+    std::ostringstream o;
+    o << fpTopPV -> GetCopyNo ();
+    fGlobalTag = fpTopPV -> GetName () + "." + o.str();
+    fGlobalDescription = "G4PhysicalVolumeModel " + fGlobalTag;
+
+    fpCurrentPV = fpTopPV;
+    if (fpCurrentPV) fpCurrentLV = fpCurrentPV->GetLogicalVolume();
+    if (fpCurrentLV) fpCurrentMaterial = fpCurrentLV->GetMaterial();
+    fpCurrentTransform = const_cast<G4Transform3D*>(&modelTransformation);
+
+    CalculateExtent ();
+  }
+}
+
+G4PhysicalVolumeModel::~G4PhysicalVolumeModel ()
+{
+  delete fpClippingSolid;
+}
+
+void G4PhysicalVolumeModel::CalculateExtent ()
+{
+  if (fUseFullExtent) {
+    fExtent = fpTopPV -> GetLogicalVolume () -> GetSolid () -> GetExtent ();
+  }
+  else {
+    G4BoundingSphereScene bsScene(this);
+    const G4int tempRequestedDepth = fRequestedDepth;
+    fRequestedDepth = -1;  // Always search to all depths to define extent.
+    const G4ModelingParameters* tempMP = fpMP;
+    G4ModelingParameters mParams
+      (0,      // No default vis attributes needed.
+       G4ModelingParameters::wf,  // wireframe (not relevant for this).
+       true,   // Global culling.
+       true,   // Cull invisible volumes.
+       false,  // Density culling.
+       0.,     // Density (not relevant if density culling false).
+       true,   // Cull daughters of opaque mothers.
+       72);    // No of sides (not relevant for this operation).
+    fpMP = &mParams;
+    DescribeYourselfTo (bsScene);
+    G4double radius = bsScene.GetRadius();
+    if (radius < 0.) {  // Nothing in the scene.
+      fExtent = fpTopPV -> GetLogicalVolume () -> GetSolid () -> GetExtent ();
+    } else {
+      // Transform back to coordinates relative to the top
+      // transformation, which is in G4VModel::fTransform.  This makes
+      // it conform to all models, which are defined by a
+      // transformation and an extent relative to that
+      // transformation...
+      G4Point3D centre = bsScene.GetCentre();
+      centre.transform(fTransform.inverse());
+      fExtent = G4VisExtent(centre, radius);
+    }
+    fpMP = tempMP;
+    fRequestedDepth = tempRequestedDepth;
+  }
+}
+
+void G4PhysicalVolumeModel::DescribeYourselfTo
+(G4VGraphicsScene& sceneHandler)
+{
+  if (!fpTopPV) G4Exception
+    ("G4PhysicalVolumeModel::DescribeYourselfTo",
+     "modeling0012", FatalException, "No model.");
+
+  if (!fpMP) G4Exception
+    ("G4PhysicalVolumeModel::DescribeYourselfTo",
+     "modeling0003", FatalException, "No modeling parameters.");
+
+  // For safety...
+  fCurrentDepth = 0;
+
+  G4Transform3D startingTransformation = fTransform;
+
+  VisitGeometryAndGetVisReps
+    (fpTopPV,
+     fRequestedDepth,
+     startingTransformation,
+     sceneHandler);
+
+  // Clear data...
+  fCurrentDepth     = 0;
+  fpCurrentPV       = 0;
+  fpCurrentLV       = 0;
+  fpCurrentMaterial = 0;
+  if (fFullPVPath.size() != fBaseFullPVPath.size()) {
+    // They should be equal if pushing and popping is happening properly.
+    G4Exception
+    ("G4PhysicalVolumeModel::DescribeYourselfTo",
+     "modeling0013",
+     FatalException,
+     "Path at start of modeling not equal to base path.  Something badly"
+     "\nwrong.  Please contact visualisation coordinator.");
+  }
+  fDrawnPVPath.clear();
+  fAbort = false;
+  fCurtailDescent = false;
+}
+
+G4String G4PhysicalVolumeModel::GetCurrentTag () const
+{
+  if (fpCurrentPV) {
+    std::ostringstream o;
+    o << fpCurrentPV -> GetCopyNo ();
+    return fpCurrentPV -> GetName () + "." + o.str();
+  }
+  else {
+    return "WARNING: NO CURRENT VOLUME - global tag is " + fGlobalTag;
+  }
+}
+
+G4String G4PhysicalVolumeModel::GetCurrentDescription () const
+{
+  return "G4PhysicalVolumeModel " + GetCurrentTag ();
+}
+
+void G4PhysicalVolumeModel::VisitGeometryAndGetVisReps
+(G4VPhysicalVolume* pVPV,
+ G4int requestedDepth,
+ const G4Transform3D& theAT,
+ G4VGraphicsScene& sceneHandler)
+{
+  // Visits geometry structure to a given depth (requestedDepth), starting
+  //   at given physical volume with given starting transformation and
+  //   describes volumes to the scene handler.
+  // requestedDepth < 0 (default) implies full visit.
+  // theAT is the Accumulated Transformation.
+
+  // Find corresponding logical volume and (later) solid, storing in
+  // local variables to preserve re-entrancy.
+  G4LogicalVolume* pLV  = pVPV -> GetLogicalVolume ();
+
+  G4VSolid* pSol;
+  G4Material* pMaterial;
+
+  if (!(pVPV -> IsReplicated ())) {
+    // Non-replicated physical volume.
+    pSol = pLV -> GetSolid ();
+    pMaterial = pLV -> GetMaterial ();
+    DescribeAndDescend (pVPV, requestedDepth, pLV, pSol, pMaterial,
+			theAT, sceneHandler);
+  }
+  else {
+    // Replicated or parametrised physical volume.
+    EAxis axis;
+    G4int nReplicas;
+    G4double width;
+    G4double offset;
+    G4bool consuming;
+    pVPV -> GetReplicationData (axis, nReplicas, width,  offset, consuming);
+    if (fCurrentDepth == 0) nReplicas = 1;  // Just draw first
+    G4VPVParameterisation* pP = pVPV -> GetParameterisation ();
+    if (pP) {  // Parametrised volume.
+      for (int n = 0; n < nReplicas; n++) {
+	pSol = pP -> ComputeSolid (n, pVPV);
+	pP -> ComputeTransformation (n, pVPV);
+	pSol -> ComputeDimensions (pP, n, pVPV);
+	pVPV -> SetCopyNo (n);
+	// Create a touchable of current parent for ComputeMaterial.
+	// fFullPVPath has not been updated yet so at this point it
+	// corresponds to the parent.
+	G4PhysicalVolumeModelTouchable parentTouchable(fFullPVPath);
+	pMaterial = pP -> ComputeMaterial (n, pVPV, &parentTouchable);
+	DescribeAndDescend (pVPV, requestedDepth, pLV, pSol, pMaterial,
+			    theAT, sceneHandler);
+      }
+    }
+    else {  // Plain replicated volume.  From geometry_guide.txt...
+      // The replica's positions are claculated by means of a linear formula.
+      // Replication may occur along:
+      // 
+      // o Cartesian axes (kXAxis,kYAxis,kZAxis)
+      // 
+      //   The replications, of specified width have coordinates of
+      //   form (-width*(nReplicas-1)*0.5+n*width,0,0) where n=0.. nReplicas-1
+      //   for the case of kXAxis, and are unrotated.
+      // 
+      // o Radial axis (cylindrical polar) (kRho)
+      // 
+      //   The replications are cons/tubs sections, centred on the origin
+      //   and are unrotated.
+      //   They have radii of width*n+offset to width*(n+1)+offset
+      //                      where n=0..nReplicas-1
+      // 
+      // o Phi axis (cylindrical polar) (kPhi)
+      //   The replications are `phi sections' or wedges, and of cons/tubs form
+      //   They have phi of offset+n*width to offset+(n+1)*width where
+      //   n=0..nReplicas-1
+      // 
+      pSol = pLV -> GetSolid ();
+      pMaterial = pLV -> GetMaterial ();
+      G4ThreeVector originalTranslation = pVPV -> GetTranslation ();
+      G4RotationMatrix* pOriginalRotation = pVPV -> GetRotation ();
+      G4double originalRMin = 0., originalRMax = 0.;
+      if (axis == kRho && pSol->GetEntityType() == "G4Tubs") {
+	originalRMin = ((G4Tubs*)pSol)->GetInnerRadius();
+	originalRMax = ((G4Tubs*)pSol)->GetOuterRadius();
+      }
+      G4bool visualisable = true;
+      for (int n = 0; n < nReplicas; n++) {
+	G4ThreeVector translation;  // Identity.
+	G4RotationMatrix rotation;  // Identity - life enough for visualizing.
+	G4RotationMatrix* pRotation = 0;
+	switch (axis) {
+	default:
+	case kXAxis:
+	  translation = G4ThreeVector (-width*(nReplicas-1)*0.5+n*width,0,0);
+	  break;
+	case kYAxis:
+	  translation = G4ThreeVector (0,-width*(nReplicas-1)*0.5+n*width,0);
+	  break;
+	case kZAxis:
+	  translation = G4ThreeVector (0,0,-width*(nReplicas-1)*0.5+n*width);
+	  break;
+	case kRho:
+	  if (pSol->GetEntityType() == "G4Tubs") {
+	    ((G4Tubs*)pSol)->SetInnerRadius(width*n+offset);
+	    ((G4Tubs*)pSol)->SetOuterRadius(width*(n+1)+offset);
+	  } else {
+	    if (fpMP->IsWarning())
+	      G4cout <<
+		"G4PhysicalVolumeModel::VisitGeometryAndGetVisReps: WARNING:"
+		"\n  built-in replicated volumes replicated in radius for "
+		     << pSol->GetEntityType() <<
+		"-type\n  solids (your solid \""
+		     << pSol->GetName() <<
+		"\") are not visualisable."
+		     << G4endl;
+	    visualisable = false;
+	  }
+	  break;
+	case kPhi:
+	  rotation.rotateZ (-(offset+(n+0.5)*width));
+	  // Minus Sign because for the physical volume we need the
+	  // coordinate system rotation.
+	  pRotation = &rotation;
+	  break;
+	} 
+	pVPV -> SetTranslation (translation);
+	pVPV -> SetRotation    (pRotation);
+	pVPV -> SetCopyNo (n);
+	if (visualisable) {
+	  DescribeAndDescend (pVPV, requestedDepth, pLV, pSol, pMaterial,
+			    theAT, sceneHandler);
+	}
+      }
+      // Restore originals...
+      pVPV -> SetTranslation (originalTranslation);
+      pVPV -> SetRotation    (pOriginalRotation);
+      if (axis == kRho && pSol->GetEntityType() == "G4Tubs") {
+	((G4Tubs*)pSol)->SetInnerRadius(originalRMin);
+	((G4Tubs*)pSol)->SetOuterRadius(originalRMax);
+      }
+    }
+  }
+}
+
+void G4PhysicalVolumeModel::DescribeAndDescend
+(G4VPhysicalVolume* pVPV,
+ G4int requestedDepth,
+ G4LogicalVolume* pLV,
+ G4VSolid* pSol,
+ G4Material* pMaterial,
+ const G4Transform3D& theAT,
+ G4VGraphicsScene& sceneHandler)
+{
+  // Maintain useful data members...
+  fpCurrentPV = pVPV;
+  fpCurrentLV = pLV;
+  fpCurrentMaterial = pMaterial;
+
+  const G4RotationMatrix objectRotation = pVPV -> GetObjectRotationValue ();
+  const G4ThreeVector&  translation     = pVPV -> GetTranslation ();
+  G4Transform3D theLT (G4Transform3D (objectRotation, translation));
+
+  // Compute the accumulated transformation...
+  // Note that top volume's transformation relative to the world
+  // coordinate system is specified in theAT == startingTransformation
+  // = fTransform (see DescribeYourselfTo), so first time through the
+  // volume's own transformation, which is only relative to its
+  // mother, i.e., not relative to the world coordinate system, should
+  // not be accumulated.
+  G4Transform3D theNewAT (theAT);
+  if (fCurrentDepth != 0) theNewAT = theAT * theLT;
+  fpCurrentTransform = &theNewAT;
+
+  const G4VisAttributes* pVisAttribs = pLV->GetVisAttributes();
+  if (!pVisAttribs) pVisAttribs = fpMP->GetDefaultVisAttributes();
+  // Beware - pVisAttribs might still be zero - probably will, since that's
+  // the default for G4ModelingParameters.  So create one if necessary...
+  if (!pVisAttribs) {
+    static G4VisAttributes defaultVisAttribs;
+    pVisAttribs = &defaultVisAttribs;
+  }
+  // From here, can assume pVisAttribs is a valid pointer.  This is necessary
+  // because PreAddSolid needs a vis attributes object.
+
+  // Make decision to draw...
+  G4bool thisToBeDrawn = true;
+  
+  // Update full path of physical volumes...
+  G4int copyNo = fpCurrentPV->GetCopyNo();
+  fFullPVPath.push_back
+  (G4PhysicalVolumeNodeID
+   (fpCurrentPV,copyNo,fCurrentDepth,*fpCurrentTransform));
+  
+  // Check if vis attributes are to be modified by a /vis/touchable/set/ command.
+  const auto& vams = fpMP->GetVisAttributesModifiers();
+  if (vams.size()) {
+    // OK, we have some VAMs (Vis Attributes Modifiers).
+    for (const auto& vam: vams) {
+      const auto& vamPath = vam.GetPVNameCopyNoPath();
+      if (vamPath.size() == fFullPVPath.size()) {
+        // OK, we have a size match.
+        // Check the volume name/copy number path.
+        auto iVAMNameCopyNo = vamPath.begin();
+        auto iPVNodeId = fFullPVPath.begin();
+        for (; iVAMNameCopyNo != vamPath.end(); ++iVAMNameCopyNo, ++iPVNodeId) {
+          if (!(
+                iVAMNameCopyNo->GetName() ==
+                iPVNodeId->GetPhysicalVolume()->GetName() &&
+                iVAMNameCopyNo->GetCopyNo() ==
+                iPVNodeId->GetPhysicalVolume()->GetCopyNo()
+                )) {
+            // This path element does NOT match.
+            break;
+          }
+        }
+        if (iVAMNameCopyNo == vamPath.end()) {
+          // OK, the paths match (the above loop terminated normally).
+          // Create a vis atts object for the modified vis atts.
+          // It is static so that we may return a reliable pointer to it.
+          static G4VisAttributes modifiedVisAtts;
+          // Initialise it with the current vis atts and reset the pointer.
+          modifiedVisAtts = *pVisAttribs;
+          pVisAttribs = &modifiedVisAtts;
+                    const G4VisAttributes& transVisAtts = vam.GetVisAttributes();
+          switch (vam.GetVisAttributesSignifier()) {
+            case G4ModelingParameters::VASVisibility:
+              modifiedVisAtts.SetVisibility(transVisAtts.IsVisible());
+              break;
+            case G4ModelingParameters::VASDaughtersInvisible:
+              modifiedVisAtts.SetDaughtersInvisible
+              (transVisAtts.IsDaughtersInvisible());
+              break;
+            case G4ModelingParameters::VASColour:
+              modifiedVisAtts.SetColour(transVisAtts.GetColour());
+              break;
+            case G4ModelingParameters::VASLineStyle:
+              modifiedVisAtts.SetLineStyle(transVisAtts.GetLineStyle());
+              break;
+            case G4ModelingParameters::VASLineWidth:
+              modifiedVisAtts.SetLineWidth(transVisAtts.GetLineWidth());
+              break;
+            case G4ModelingParameters::VASForceWireframe:
+              if (transVisAtts.IsForceDrawingStyle()) {
+                if (transVisAtts.GetForcedDrawingStyle() ==
+                    G4VisAttributes::wireframe) {
+                  modifiedVisAtts.SetForceWireframe(true);
+                }
+              }
+              break;
+            case G4ModelingParameters::VASForceSolid:
+              if (transVisAtts.IsForceDrawingStyle()) {
+                if (transVisAtts.GetForcedDrawingStyle() ==
+                    G4VisAttributes::solid) {
+                  modifiedVisAtts.SetForceSolid(true);
+                }
+              }
+              break;
+            case G4ModelingParameters::VASForceAuxEdgeVisible:
+              if (transVisAtts.IsForceAuxEdgeVisible()) {
+                modifiedVisAtts.SetForceAuxEdgeVisible
+                (transVisAtts.IsForcedAuxEdgeVisible());
+              }
+              break;
+            case G4ModelingParameters::VASForceLineSegmentsPerCircle:
+              modifiedVisAtts.SetForceLineSegmentsPerCircle
+              (transVisAtts.GetForcedLineSegmentsPerCircle());
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  // There are various reasons why this volume
+  // might not be drawn...
+  G4bool culling = fpMP->IsCulling();
+  G4bool cullingInvisible = fpMP->IsCullingInvisible();
+  G4bool markedVisible = pVisAttribs->IsVisible();
+  G4bool cullingLowDensity = fpMP->IsDensityCulling();
+  G4double density = pMaterial? pMaterial->GetDensity(): 0;
+  G4double densityCut = fpMP -> GetVisibleDensity ();
+
+  // 1) Global culling is on....
+  if (culling) {
+    // 2) Culling of invisible volumes is on...
+    if (cullingInvisible) {
+      // 3) ...and the volume is marked not visible...
+      if (!markedVisible) thisToBeDrawn = false;
+    }
+    // 4) Or culling of low density volumes is on...
+    if (cullingLowDensity) {
+      // 5) ...and density is less than cut value...
+      if (density < densityCut) thisToBeDrawn = false;
+    }
+  }
+  // 6) The user has asked for all further traversing to be aborted...
+  if (fAbort) thisToBeDrawn = false;
+
+#ifdef BYPASS_DRAWING_CLIPPED_VOLUMES
+
+  // Check if a view clipping operation cuts this volume from the scene
+
+  bool thisToBeBypassed = false;
+  G4VSolid* pIntersector = fpMP->GetSectionSolid();
+  G4VSolid* pSubtractor = fpMP->GetCutawaySolid();
+  if (fpClippingSolid) {
+    switch (fClippingMode) {
+     case subtraction:
+       pSubtractor = fpClippingSolid;
+       break;
+     case intersection:
+       pIntersector = fpClippingSolid;
+       break;
+    }
+  }
+
+  G4DisplacedSolid *pClipper;
+  if ((pClipper = dynamic_cast<G4DisplacedSolid*>(pIntersector)))
+  {
+    G4AffineTransform clipAT(pClipper->GetTransform());
+    G4AffineTransform currAT(fpCurrentTransform->getRotation().inverse(),
+                             fpCurrentTransform->getTranslation());
+    G4AffineTransform combAT;
+    combAT.Product(currAT,clipAT);
+    G4DisplacedSolid pClipped("temporary_to_clip",pSol,combAT);
+    G4VisExtent clipper(pClipper->GetConstituentMovedSolid()->GetExtent());
+    G4VisExtent clipped(pClipped.GetExtent());
+    thisToBeBypassed = (clipper.GetXmax() < clipped.GetXmin())
+                    || (clipper.GetXmin() > clipped.GetXmax())
+                    || (clipper.GetYmax() < clipped.GetYmin())
+                    || (clipper.GetYmin() > clipped.GetYmax())
+                    || (clipper.GetZmax() < clipped.GetZmin())
+                    || (clipper.GetZmin() > clipped.GetZmax());
+  }
+
+  if ((pClipper = dynamic_cast<G4DisplacedSolid*>(pSubtractor)))
+  {
+    G4AffineTransform clipAT(pClipper->GetTransform());
+    G4AffineTransform currAT(fpCurrentTransform->getRotation().inverse(),
+                             fpCurrentTransform->getTranslation());
+    G4AffineTransform combAT;
+    combAT.Product(currAT,clipAT);
+    G4DisplacedSolid pClipped("temporary_to_clip",pSol,combAT);
+    G4VisExtent clipper(pClipper->GetConstituentMovedSolid()->GetExtent());
+    G4VisExtent clipped(pClipped.GetExtent());
+    thisToBeBypassed = (clipper.GetXmax() > clipped.GetXmax())
+                    && (clipper.GetXmin() < clipped.GetXmin())
+                    && (clipper.GetYmax() > clipped.GetYmax())
+                    && (clipper.GetYmin() < clipped.GetYmin())
+                    && (clipper.GetZmax() > clipped.GetZmax())
+                    && (clipper.GetZmin() < clipped.GetZmin());
+  }
+
+  thisToBeDrawn = thisToBeDrawn && (! thisToBeBypassed);
+
+#endif
+
+  // Record thisToBeDrawn in path...
+  fFullPVPath.back().SetDrawn(thisToBeDrawn);
+
+  if (thisToBeDrawn) {
+
+    // Update path of drawn physical volumes...
+    fDrawnPVPath.push_back
+      (G4PhysicalVolumeNodeID
+       (fpCurrentPV,copyNo,fCurrentDepth,*fpCurrentTransform,thisToBeDrawn));
+
+    if (fpMP->IsExplode() && fDrawnPVPath.size() == 1) {
+      // For top-level drawn volumes, explode along radius...
+      G4Transform3D centering = G4Translate3D(fpMP->GetExplodeCentre());
+      G4Transform3D centred = centering.inverse() * theNewAT;
+      G4Scale3D oldScale;
+      G4Rotate3D oldRotation;
+      G4Translate3D oldTranslation;
+      centred.getDecomposition(oldScale, oldRotation, oldTranslation);
+      G4double explodeFactor = fpMP->GetExplodeFactor();
+      G4Translate3D newTranslation =
+	G4Translate3D(explodeFactor * oldTranslation.dx(),
+		      explodeFactor * oldTranslation.dy(),
+		      explodeFactor * oldTranslation.dz());
+      theNewAT = centering * newTranslation * oldRotation * oldScale;
+    }
+
+    DescribeSolid (theNewAT, pSol, pVisAttribs, sceneHandler);
+
+  }
+
+  // Make decision to draw daughters, if any.  There are various
+  // reasons why daughters might not be drawn...
+
+  // First, reasons that do not depend on culling policy...
+  G4int nDaughters = pLV->GetNoDaughters();
+#ifdef BYPASS_DRAWING_CLIPPED_VOLUMES
+  G4bool daughtersToBeDrawn = ! thisToBeBypassed;
+#else
+  G4bool daughtersToBeDrawn = true;
+#endif
+  // 1) There are no daughters...
+  if (!nDaughters) daughtersToBeDrawn = false;
+  // 2) We are at the limit if requested depth...
+  else if (requestedDepth == 0) daughtersToBeDrawn = false;
+  // 3) The user has asked for all further traversing to be aborted...
+  else if (fAbort) daughtersToBeDrawn = false;
+  // 4) The user has asked that the descent be curtailed...
+  else if (fCurtailDescent) daughtersToBeDrawn = false;
+
+  // Now, reasons that depend on culling policy...
+  else {
+    G4bool daughtersInvisible = pVisAttribs->IsDaughtersInvisible();
+    // Culling of covered daughters request.  This is computed in
+    // G4VSceneHandler::CreateModelingParameters() depending on view
+    // parameters...
+    G4bool cullingCovered = fpMP->IsCullingCovered();
+    G4bool surfaceDrawing =
+      fpMP->GetDrawingStyle() == G4ModelingParameters::hsr ||
+      fpMP->GetDrawingStyle() == G4ModelingParameters::hlhsr;    
+    if (pVisAttribs->IsForceDrawingStyle()) {
+      switch (pVisAttribs->GetForcedDrawingStyle()) {
+      default:
+      case G4VisAttributes::wireframe: surfaceDrawing = false; break;
+      case G4VisAttributes::solid: surfaceDrawing = true; break;
+      }
+    }
+    G4bool opaque = pVisAttribs->GetColour().GetAlpha() >= 1.;
+    // 5) Global culling is on....
+    if (culling) {
+      // 6) ..and culling of invisible volumes is on...
+      if (cullingInvisible) {
+	// 7) ...and the mother requests daughters invisible
+	if (daughtersInvisible) daughtersToBeDrawn = false;
+      }
+      // 8) Or culling of covered daughters is requested...
+      if (cullingCovered) {
+	// 9) ...and surface drawing is operating...
+	if (surfaceDrawing) {
+	  // 10) ...but only if mother is visible...
+	  if (thisToBeDrawn) {
+	    // 11) ...and opaque...
+	      if (opaque) daughtersToBeDrawn = false;
+	  }
+	}
+      }
+    }
+  }
+
+  if (daughtersToBeDrawn) {
+    for (G4int iDaughter = 0; iDaughter < nDaughters; iDaughter++) {
+      // Store daughter pVPV in local variable ready for recursion...
+      G4VPhysicalVolume* pDaughterVPV = pLV -> GetDaughter (iDaughter);
+      // Descend the geometry structure recursively...
+      fCurrentDepth++;
+      VisitGeometryAndGetVisReps
+	(pDaughterVPV, requestedDepth - 1, theNewAT, sceneHandler);
+      fCurrentDepth--;
+    }
+  }
+
+  // Reset for normal descending of next volume at this level...
+  fCurtailDescent = false;
+
+  // Pop item from paths physical volumes...
+  fFullPVPath.pop_back();
+  if (thisToBeDrawn) {
+    fDrawnPVPath.pop_back();
+  }
+}
+
+void G4PhysicalVolumeModel::DescribeSolid
+(const G4Transform3D& theAT,
+ G4VSolid* pSol,
+ const G4VisAttributes* pVisAttribs,
+ G4VGraphicsScene& sceneHandler)
+{
+  sceneHandler.PreAddSolid (theAT, *pVisAttribs);
+
+  G4VSolid* pSectionSolid = fpMP->GetSectionSolid();
+  G4VSolid* pCutawaySolid = fpMP->GetCutawaySolid();
+
+  if (!fpClippingSolid && !pSectionSolid && !pCutawaySolid) {
+
+    pSol -> DescribeYourselfTo (sceneHandler);  // Standard treatment.
+
+  } else {
+
+    // Clipping, etc., performed by Boolean operations.
+
+    // First, get polyhedron for current solid...
+    if (pVisAttribs->IsForceLineSegmentsPerCircle())
+      G4Polyhedron::SetNumberOfRotationSteps
+	(pVisAttribs->GetForcedLineSegmentsPerCircle());
+    else
+      G4Polyhedron::SetNumberOfRotationSteps(fpMP->GetNoOfSides());
+    const G4Polyhedron* pOriginal = pSol->GetPolyhedron();
+    //G4Polyhedron::ResetNumberOfRotationSteps();
+
+    if (!pOriginal) {
+
+      if (fpMP->IsWarning())
+	G4cout <<
+	  "WARNING: G4PhysicalVolumeModel::DescribeSolid: solid\n  \""
+	       << pSol->GetName() <<
+	  "\" has no polyhedron.  Cannot by clipped."
+	       << G4endl;
+      pSol -> DescribeYourselfTo (sceneHandler);  // Standard treatment.
+
+    } else {
+
+      G4Polyhedron resultant(*pOriginal);
+      G4VisAttributes resultantVisAttribs(*pVisAttribs);
+      G4VSolid* resultantSolid = 0;
+
+      if (fpClippingSolid) {
+	switch (fClippingMode) {
+	default:
+	case subtraction:
+	  resultantSolid = new G4SubtractionSolid
+	    ("resultant_solid", pSol, fpClippingSolid, theAT.inverse());
+	  break;
+	case intersection:
+	  resultantSolid = new G4IntersectionSolid
+	    ("resultant_solid", pSol, fpClippingSolid, theAT.inverse());
+	  break;
+	}
+      }
+
+      if (pSectionSolid) {
+	resultantSolid = new G4IntersectionSolid
+	  ("sectioned_solid", pSol, pSectionSolid, theAT.inverse());
+      }
+
+      if (pCutawaySolid) {
+	resultantSolid = new G4SubtractionSolid
+	  ("cutaway_solid", pSol, pCutawaySolid, theAT.inverse());
+      }
+
+      G4Polyhedron* tmpResultant = resultantSolid->GetPolyhedron();
+      if (tmpResultant) resultant = *tmpResultant;
+      else {
+	if (fpMP->IsWarning())
+	  G4cout <<
+	    "WARNING: G4PhysicalVolumeModel::DescribeSolid: resultant polyhedron for"
+	    "\n  solid \"" << pSol->GetName() <<
+	    "\" not defined due to error during Boolean processing."
+	    "\n  Original will be drawn in red."
+		 << G4endl;
+	resultantVisAttribs.SetColour(G4Colour::Red());
+      }
+
+      delete resultantSolid;
+
+      // Finally, force polyhedron drawing...
+      resultant.SetVisAttributes(resultantVisAttribs);
+      sceneHandler.BeginPrimitives(theAT);
+      sceneHandler.AddPrimitive(resultant);
+      sceneHandler.EndPrimitives();
+    }
+  }
+  sceneHandler.PostAddSolid ();
+}
+
+G4bool G4PhysicalVolumeModel::Validate (G4bool warn)
+{
+  G4TransportationManager* transportationManager =
+    G4TransportationManager::GetTransportationManager ();
+
+  size_t nWorlds = transportationManager->GetNoWorlds();
+
+  G4bool found = false;
+
+  std::vector<G4VPhysicalVolume*>::iterator iterWorld =
+    transportationManager->GetWorldsIterator();
+  for (size_t i = 0; i < nWorlds; ++i, ++iterWorld) {
+    G4VPhysicalVolume* world = (*iterWorld);
+    // The idea now is to seek a PV with the same name and copy no
+    // in the hope it's the same one!!
+    G4PhysicalVolumeModel searchModel (world);
+    G4int verbosity = 0;  // Suppress messages from G4PhysicalVolumeSearchScene.
+    G4PhysicalVolumeSearchScene searchScene
+      (&searchModel, fTopPVName, fTopPVCopyNo, verbosity);
+    G4ModelingParameters mp;  // Default modeling parameters for this search.
+    mp.SetDefaultVisAttributes(fpMP? fpMP->GetDefaultVisAttributes(): 0);
+    searchModel.SetModelingParameters (&mp);
+    searchModel.DescribeYourselfTo (searchScene);
+    G4VPhysicalVolume* foundVolume = searchScene.GetFoundVolume ();
+    if (foundVolume) {
+      if (foundVolume != fpTopPV && warn) {
+	G4cout <<
+	  "G4PhysicalVolumeModel::Validate(): A volume of the same name and"
+	  "\n  copy number (\""
+	       << fTopPVName << "\", copy " << fTopPVCopyNo
+	       << ") still exists and is being used."
+	  "\n  But it is not the same volume you originally specified"
+	  "\n  in /vis/scene/add/."
+	       << G4endl;
+      }
+      fpTopPV = foundVolume;
+      CalculateExtent ();
+      found = true;
+    }
+  }
+  if (found) return true;
+  else {
+    if (warn) {
+      G4cout <<
+	"G4PhysicalVolumeModel::Validate(): No volume of name and"
+	"\n  copy number (\""
+	     << fTopPVName << "\", copy " << fTopPVCopyNo
+	     << ") exists."
+	     << G4endl;
+    }
+    return false;
+  }
+}
+
+const std::map<G4String,G4AttDef>* G4PhysicalVolumeModel::GetAttDefs() const
+{
+    G4bool isNew;
+    std::map<G4String,G4AttDef>* store
+      = G4AttDefStore::GetInstance("G4PhysicalVolumeModel", isNew);
+    if (isNew) {
+      (*store)["PVPath"] =
+	G4AttDef("PVPath","Physical Volume Path","Physics","","G4String");
+      (*store)["LVol"] =
+	G4AttDef("LVol","Logical Volume","Physics","","G4String");
+      (*store)["Solid"] =
+	G4AttDef("Solid","Solid Name","Physics","","G4String");
+      (*store)["EType"] =
+	G4AttDef("EType","Entity Type","Physics","","G4String");
+      (*store)["DmpSol"] =
+	G4AttDef("DmpSol","Dump of Solid properties","Physics","","G4String");
+      (*store)["LocalTrans"] =
+    G4AttDef("LocalTrans","Local transformation of volume","Physics","","G4String");
+      (*store)["GlobalTrans"] =
+    G4AttDef("GlobalTrans","Global transformation of volume","Physics","","G4String");
+      (*store)["Material"] =
+	G4AttDef("Material","Material Name","Physics","","G4String");
+      (*store)["Density"] =
+	G4AttDef("Density","Material Density","Physics","G4BestUnit","G4double");
+      (*store)["State"] =
+	G4AttDef("State","Material State (enum undefined,solid,liquid,gas)","Physics","","G4String");
+      (*store)["Radlen"] =
+	G4AttDef("Radlen","Material Radiation Length","Physics","G4BestUnit","G4double");
+      (*store)["Region"] =
+	G4AttDef("Region","Cuts Region","Physics","","G4String");
+      (*store)["RootRegion"] =
+	G4AttDef("RootRegion","Root Region (0/1 = false/true)","Physics","","G4bool");
+    }
+  return store;
+}
+
+#include <iomanip>
+
+static std::ostream& operator<< (std::ostream& o, const G4Transform3D t)
+{
+  using namespace std;
+
+  G4Scale3D sc;
+  G4Rotate3D r;
+  G4Translate3D tl;
+  t.getDecomposition(sc, r, tl);
+
+  const int w = 10;
+
+  // Transformation itself
+  o << setw(w) << t.xx() << setw(w) << t.xy() << setw(w) << t.xz() << setw(w) << t.dx() << endl;
+  o << setw(w) << t.yx() << setw(w) << t.yy() << setw(w) << t.yz() << setw(w) << t.dy() << endl;
+  o << setw(w) << t.zx() << setw(w) << t.zy() << setw(w) << t.zz() << setw(w) << t.dz() << endl;
+
+  // Translation
+  o << "= translation:" << endl;
+  o << setw(w) << tl.dx() << setw(w) << tl.dy() << setw(w) << tl.dz() << endl;
+
+  // Rotation
+  o << "* rotation:" << endl;
+  o << setw(w) << r.xx() << setw(w) << r.xy() << setw(w) << r.xz() << endl;
+  o << setw(w) << r.yx() << setw(w) << r.yy() << setw(w) << r.yz() << endl;
+  o << setw(w) << r.zx() << setw(w) << r.zy() << setw(w) << r.zz() << endl;
+
+  // Scale
+  o << "* scale:" << endl;
+  o << setw(w) << sc.xx() << setw(w) << sc.yy() << setw(w) << sc.zz() << endl;
+
+  // Transformed axes
+  o << "Transformed axes:" << endl;
+  o << "x': " << r * G4Vector3D(1., 0., 0.) << endl;
+  o << "y': " << r * G4Vector3D(0., 1., 0.) << endl;
+  o << "z': " << r * G4Vector3D(0., 0., 1.) << endl;
+
+  return o;
+}
+
+std::vector<G4AttValue>* G4PhysicalVolumeModel::CreateCurrentAttValues() const
+{
+  std::vector<G4AttValue>* values = new std::vector<G4AttValue>;
+  std::ostringstream oss;
+  for (size_t i = 0; i < fFullPVPath.size(); ++i) {
+    oss << fFullPVPath[i].GetPhysicalVolume()->GetName()
+	<< ':' << fFullPVPath[i].GetCopyNo();
+    if (i != fFullPVPath.size() - 1) oss << '/';
+  }
+
+  if (!fpCurrentLV) {
+     G4Exception
+        ("G4PhysicalVolumeModel::CreateCurrentAttValues",
+         "modeling0004",
+         JustWarning,
+         "Current logical volume not defined.");
+     return values;
+  }
+
+  values->push_back(G4AttValue("PVPath", oss.str(),""));
+  values->push_back(G4AttValue("LVol", fpCurrentLV->GetName(),""));
+  G4VSolid* pSol = fpCurrentLV->GetSolid();
+  values->push_back(G4AttValue("Solid", pSol->GetName(),""));
+  values->push_back(G4AttValue("EType", pSol->GetEntityType(),""));
+  oss.str(""); oss << '\n' << *pSol;
+  values->push_back(G4AttValue("DmpSol", oss.str(),""));
+  const G4RotationMatrix localRotation = fpCurrentPV->GetObjectRotationValue();
+  const G4ThreeVector& localTranslation = fpCurrentPV->GetTranslation();
+  oss.str(""); oss << '\n' << G4Transform3D(localRotation,localTranslation);
+  values->push_back(G4AttValue("LocalTrans", oss.str(),""));
+  oss.str(""); oss << '\n' << *fpCurrentTransform;
+  values->push_back(G4AttValue("GlobalTrans", oss.str(),""));
+  G4String matName = fpCurrentMaterial? fpCurrentMaterial->GetName(): G4String("No material");
+  values->push_back(G4AttValue("Material", matName,""));
+  G4double matDensity = fpCurrentMaterial? fpCurrentMaterial->GetDensity(): 0.;
+  values->push_back(G4AttValue("Density", G4BestUnit(matDensity,"Volumic Mass"),""));
+  G4State matState = fpCurrentMaterial? fpCurrentMaterial->GetState(): kStateUndefined;
+  oss.str(""); oss << matState;
+  values->push_back(G4AttValue("State", oss.str(),""));
+  G4double matRadlen = fpCurrentMaterial? fpCurrentMaterial->GetRadlen(): 0.;
+  values->push_back(G4AttValue("Radlen", G4BestUnit(matRadlen,"Length"),""));
+  G4Region* region = fpCurrentLV->GetRegion();
+  G4String regionName = region? region->GetName(): G4String("No region");
+  values->push_back(G4AttValue("Region", regionName,""));
+  oss.str(""); oss << fpCurrentLV->IsRootRegion();
+  values->push_back(G4AttValue("RootRegion", oss.str(),""));
+  return values;
+}
+
+G4bool G4PhysicalVolumeModel::G4PhysicalVolumeNodeID::operator<
+  (const G4PhysicalVolumeModel::G4PhysicalVolumeNodeID& right) const
+{
+  if (fpPV < right.fpPV) return true;
+  if (fpPV == right.fpPV) {
+    if (fCopyNo < right.fCopyNo) return true;
+    if (fCopyNo == right.fCopyNo)
+      return fNonCulledDepth < right.fNonCulledDepth;
+  }
+  return false;
+}
+
+std::ostream& operator<<
+  (std::ostream& os, const G4PhysicalVolumeModel::G4PhysicalVolumeNodeID& node)
+{
+  G4VPhysicalVolume* pPV = node.GetPhysicalVolume();
+  if (pPV) {
+    os << pPV->GetName()
+       << ' ' << node.GetCopyNo()
+//       << '[' << node.GetNonCulledDepth() << ']'
+//       << ':' << node.GetTransform()
+    ;
+//    os << " (";
+//    if (!node.GetDrawn()) os << "not ";
+//    os << "drawn)";
+  } else {
+    os << " (Null node)";
+  }
+  return os;
+}
+
+std::ostream& operator<<
+(std::ostream& os, const std::vector<G4PhysicalVolumeModel::G4PhysicalVolumeNodeID>& path)
+{
+  for (const auto& nodeID: path) {
+    os << nodeID << ' ';
+  }
+  return os;
+}
+
+G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::G4PhysicalVolumeModelTouchable
+(const std::vector<G4PhysicalVolumeNodeID>& fullPVPath):
+  fFullPVPath(fullPVPath) {}
+
+const G4ThreeVector& G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::GetTranslation(G4int depth) const
+{
+  size_t i = fFullPVPath.size() - depth - 1;
+  if (i >= fFullPVPath.size()) {
+    G4Exception("G4PhysicalVolumeModelTouchable::GetTranslation",
+		"modeling0005",
+		FatalErrorInArgument,
+		"Index out of range. Asking for non-existent depth");
+  }
+  static G4ThreeVector tempTranslation;
+  tempTranslation = fFullPVPath[i].GetTransform().getTranslation();
+  return tempTranslation;
+}
+
+const G4RotationMatrix* G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::GetRotation(G4int depth) const
+{
+  size_t i = fFullPVPath.size() - depth - 1;
+  if (i >= fFullPVPath.size()) {
+    G4Exception("G4PhysicalVolumeModelTouchable::GetRotation",
+		"modeling0006",
+		FatalErrorInArgument,
+		"Index out of range. Asking for non-existent depth");
+  }
+  static G4RotationMatrix tempRotation;
+  tempRotation = fFullPVPath[i].GetTransform().getRotation();
+  return &tempRotation;
+}
+
+G4VPhysicalVolume* G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::GetVolume(G4int depth) const
+{
+  size_t i = fFullPVPath.size() - depth - 1;
+  if (i >= fFullPVPath.size()) {
+    G4Exception("G4PhysicalVolumeModelTouchable::GetVolume",
+		"modeling0007",
+		FatalErrorInArgument,
+		"Index out of range. Asking for non-existent depth");
+  }
+  return fFullPVPath[i].GetPhysicalVolume();
+}
+
+G4VSolid* G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::GetSolid(G4int depth) const
+{
+  size_t i = fFullPVPath.size() - depth - 1;
+  if (i >= fFullPVPath.size()) {
+    G4Exception("G4PhysicalVolumeModelTouchable::GetSolid",
+		"modeling0008",
+		FatalErrorInArgument,
+		"Index out of range. Asking for non-existent depth");
+  }
+  return fFullPVPath[i].GetPhysicalVolume()->GetLogicalVolume()->GetSolid();
+}
+
+G4int G4PhysicalVolumeModel::G4PhysicalVolumeModelTouchable::GetReplicaNumber(G4int depth) const
+{
+  size_t i = fFullPVPath.size() - depth - 1;
+  if (i >= fFullPVPath.size()) {
+    G4Exception("G4PhysicalVolumeModelTouchable::GetReplicaNumber",
+		"modeling0009",
+		FatalErrorInArgument,
+		"Index out of range. Asking for non-existent depth");
+  }
+  return fFullPVPath[i].GetCopyNo();
+}

--- a/src/G4.10.03.p01fixes/G4Tubs.cc
+++ b/src/G4.10.03.p01fixes/G4Tubs.cc
@@ -1,0 +1,1777 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4Tubs.cc 101121 2016-11-07 09:18:01Z gcosmo $
+//
+// 
+// class G4Tubs
+//
+// History:
+//
+// 24.08.16 E.Tcherniaev: reimplemented CalculateExtent() to make use
+//                      of G4BoundingEnvelope  
+// 05.04.12 M.Kelsey:   Use sqrt(r) in GetPointOnSurface() for uniform points
+// 02.08.07 T.Nikitina: bug fixed in DistanceToOut(p,v,..) for negative value under sqrt
+//                      for the case: p on the surface and v is tangent to the surface
+// 11.05.07 T.Nikitina: bug fixed in DistanceToOut(p,v,..) for phi < 2pi
+// 03.05.05 V.Grichine: SurfaceNormal(p) according to J. Apostolakis proposal
+// 16.03.05 V.Grichine: SurfaceNormal(p) with edges/corners for boolean
+// 20.07.01 V.Grichine: bug fixed in Inside(p)
+// 20.02.01 V.Grichine: bug fixed in Inside(p) and CalculateExtent was 
+//                      simplified base on G4Box::CalculateExtent
+// 07.12.00 V.Grichine: phi-section algorithm was changed in Inside(p)
+// 28.11.00 V.Grichine: bug fixed in Inside(p)
+// 31.10.00 V.Grichine: assign srd, sphi in Distance ToOut(p,v,...)
+// 08.08.00 V.Grichine: more stable roots of 2-equation in DistanceToOut(p,v,..)
+// 02.08.00 V.Grichine: point is outside check in Distance ToOut(p)
+// 17.05.00 V.Grichine: bugs (#76,#91) fixed in Distance ToOut(p,v,...)
+// 31.03.00 V.Grichine: bug fixed in Inside(p)
+// 19.11.99 V.Grichine: side = kNull in DistanceToOut(p,v,...)
+// 13.10.99 V.Grichine: bugs fixed in DistanceToIn(p,v) 
+// 28.05.99 V.Grichine: bugs fixed in DistanceToOut(p,v,...)
+// 25.05.99 V.Grichine: bugs fixed in DistanceToIn(p,v) 
+// 23.03.99 V.Grichine: bug fixed in DistanceToIn(p,v) 
+// 09.10.98 V.Grichine: modifications in DistanceToOut(p,v,...)
+// 18.06.98 V.Grichine: n-normalisation in DistanceToOut(p,v)
+// 
+// 1994-95  P.Kent:     implementation
+//
+/////////////////////////////////////////////////////////////////////////
+
+#include "G4Tubs.hh"
+
+#if !defined(G4GEOM_USE_UTUBS)
+
+#include "G4GeomTools.hh"
+#include "G4VoxelLimits.hh"
+#include "G4AffineTransform.hh"
+#include "G4GeometryTolerance.hh"
+#include "G4BoundingEnvelope.hh"
+
+#include "G4VPVParameterisation.hh"
+
+#include "Randomize.hh"
+
+#include "meshdefs.hh"
+
+#include "G4VGraphicsScene.hh"
+
+using namespace CLHEP;
+
+/////////////////////////////////////////////////////////////////////////
+//
+// Constructor - check parameters, convert angles so 0<sphi+dpshi<=2_PI
+//             - note if pdphi>2PI then reset to 2PI
+
+G4Tubs::G4Tubs( const G4String &pName,
+                      G4double pRMin, G4double pRMax,
+                      G4double pDz,
+                      G4double pSPhi, G4double pDPhi )
+  : G4CSGSolid(pName), fRMin(pRMin), fRMax(pRMax), fDz(pDz), fSPhi(0), fDPhi(0)
+{
+
+  kRadTolerance = G4GeometryTolerance::GetInstance()->GetRadialTolerance();
+  kAngTolerance = G4GeometryTolerance::GetInstance()->GetAngularTolerance();
+
+  halfCarTolerance=kCarTolerance*0.5;
+  halfRadTolerance=kRadTolerance*0.5;
+  halfAngTolerance=kAngTolerance*0.5;
+
+  if (pDz<=0) // Check z-len
+  {
+    std::ostringstream message;
+    message << "Negative Z half-length (" << pDz << ") in solid: " << GetName();
+    G4Exception("G4Tubs::G4Tubs()", "GeomSolids0002", FatalException, message);
+  }
+  if ( (pRMin >= pRMax) || (pRMin < 0) ) // Check radii
+  {
+    std::ostringstream message;
+    message << "Invalid values for radii in solid: " << GetName()
+            << G4endl
+            << "        pRMin = " << pRMin << ", pRMax = " << pRMax;
+    G4Exception("G4Tubs::G4Tubs()", "GeomSolids0002", FatalException, message);
+  }
+
+  // Check angles
+  //
+  CheckPhiAngles(pSPhi, pDPhi);
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+// Fake default constructor - sets only member data and allocates memory
+//                            for usage restricted to object persistency.
+//
+G4Tubs::G4Tubs( __void__& a )
+  : G4CSGSolid(a), kRadTolerance(0.), kAngTolerance(0.),
+    fRMin(0.), fRMax(0.), fDz(0.), fSPhi(0.), fDPhi(0.),
+    sinCPhi(0.), cosCPhi(0.), cosHDPhiOT(0.), cosHDPhiIT(0.),
+    sinSPhi(0.), cosSPhi(0.), sinEPhi(0.), cosEPhi(0.),
+    fPhiFullTube(false), halfCarTolerance(0.), halfRadTolerance(0.),
+    halfAngTolerance(0.)
+{
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Destructor
+
+G4Tubs::~G4Tubs()
+{
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Copy constructor
+
+G4Tubs::G4Tubs(const G4Tubs& rhs)
+  : G4CSGSolid(rhs),
+    kRadTolerance(rhs.kRadTolerance), kAngTolerance(rhs.kAngTolerance),
+    fRMin(rhs.fRMin), fRMax(rhs.fRMax), fDz(rhs.fDz),
+    fSPhi(rhs.fSPhi), fDPhi(rhs.fDPhi),
+    sinCPhi(rhs.sinCPhi), cosCPhi(rhs.cosCPhi),
+    cosHDPhiOT(rhs.cosHDPhiOT), cosHDPhiIT(rhs.cosHDPhiIT),
+    sinSPhi(rhs.sinSPhi), cosSPhi(rhs.cosSPhi),
+    sinEPhi(rhs.sinEPhi), cosEPhi(rhs.cosEPhi), fPhiFullTube(rhs.fPhiFullTube),
+    halfCarTolerance(rhs.halfCarTolerance),
+    halfRadTolerance(rhs.halfRadTolerance),
+    halfAngTolerance(rhs.halfAngTolerance)
+{
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Assignment operator
+
+G4Tubs& G4Tubs::operator = (const G4Tubs& rhs) 
+{
+   // Check assignment to self
+   //
+   if (this == &rhs)  { return *this; }
+
+   // Copy base class data
+   //
+   G4CSGSolid::operator=(rhs);
+
+   // Copy data
+   //
+   kRadTolerance = rhs.kRadTolerance; kAngTolerance = rhs.kAngTolerance;
+   fRMin = rhs.fRMin; fRMax = rhs.fRMax; fDz = rhs.fDz;
+   fSPhi = rhs.fSPhi; fDPhi = rhs.fDPhi;
+   sinCPhi = rhs.sinCPhi; cosCPhi = rhs.cosCPhi;
+   cosHDPhiOT = rhs.cosHDPhiOT; cosHDPhiIT = rhs.cosHDPhiIT;
+   sinSPhi = rhs.sinSPhi; cosSPhi = rhs.cosSPhi;
+   sinEPhi = rhs.sinEPhi; cosEPhi = rhs.cosEPhi;
+   fPhiFullTube = rhs.fPhiFullTube;
+   halfCarTolerance = rhs.halfCarTolerance;
+   halfRadTolerance = rhs.halfRadTolerance;
+   halfAngTolerance = rhs.halfAngTolerance;
+
+   return *this;
+}
+
+/////////////////////////////////////////////////////////////////////////
+//
+// Dispatch to parameterisation for replication mechanism dimension
+// computation & modification.
+
+void G4Tubs::ComputeDimensions(       G4VPVParameterisation* p,
+                                const G4int n,
+                                const G4VPhysicalVolume* pRep )
+{
+  p->ComputeDimensions(*this,n,pRep) ;
+}
+
+/////////////////////////////////////////////////////////////////////////
+//
+// Get bounding box
+
+void G4Tubs::Extent(G4ThreeVector& pMin, G4ThreeVector& pMax) const
+{
+  G4double rmin = GetInnerRadius();
+  G4double rmax = GetOuterRadius();
+  G4double dz   = GetZHalfLength();
+
+  // Find bounding box
+  //
+  if (GetDeltaPhiAngle() < twopi)
+  {
+    G4TwoVector vmin,vmax;
+    G4GeomTools::DiskExtent(rmin,rmax,
+                            GetSinStartPhi(),GetCosStartPhi(),
+                            GetSinEndPhi(),GetCosEndPhi(),
+                            vmin,vmax);
+    pMin.set(vmin.x(),vmin.y(),-dz);
+    pMax.set(vmax.x(),vmax.y(), dz);
+  }
+  else
+  {
+    pMin.set(-rmax,-rmax,-dz);
+    pMax.set( rmax, rmax, dz);
+  }
+
+  // Check correctness of the bounding box
+  //
+  if (pMin.x() >= pMax.x() || pMin.y() >= pMax.y() || pMin.z() >= pMax.z())
+  {
+    std::ostringstream message;
+    message << "Bad bounding box (min >= max) for solid: "
+            << GetName() << " !"
+            << "\npMin = " << pMin
+            << "\npMax = " << pMax;
+    G4Exception("G4Tubs::Extent()", "GeomMgt0001", JustWarning, message);
+    DumpInfo();
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////
+//
+// Calculate extent under transform and specified limit
+
+G4bool G4Tubs::CalculateExtent( const EAxis              pAxis,
+                                const G4VoxelLimits&     pVoxelLimit,
+                                const G4AffineTransform& pTransform,
+                                      G4double&          pMin, 
+                                      G4double&          pMax    ) const
+{
+  G4ThreeVector bmin, bmax;
+  G4bool exist;
+
+  // Get bounding box
+  Extent(bmin,bmax);
+
+  // Check bounding box
+  G4BoundingEnvelope bbox(bmin,bmax);
+#ifdef G4BBOX_EXTENT
+  if (true) return bbox.CalculateExtent(pAxis,pVoxelLimit,pTransform,pMin,pMax);
+#endif
+  if (bbox.BoundingBoxVsVoxelLimits(pAxis,pVoxelLimit,pTransform,pMin,pMax))
+  {
+    return exist = (pMin < pMax) ? true : false;
+  }
+
+  // Get parameters of the solid
+  G4double rmin = GetInnerRadius();
+  G4double rmax = GetOuterRadius();
+  G4double dz   = GetZHalfLength();
+  G4double dphi = GetDeltaPhiAngle();
+
+  // Find bounding envelope and calculate extent
+  //
+  const G4int NSTEPS = 24;            // number of steps for whole circle
+  G4double astep  = (360/NSTEPS)*deg; // max angle for one step
+  G4int    ksteps = (dphi <= astep) ? 1 : (G4int)((dphi-deg)/astep) + 1;
+  G4double ang    = dphi/ksteps;
+
+  G4double sinHalf = std::sin(0.5*ang);
+  G4double cosHalf = std::cos(0.5*ang);
+  G4double sinStep = 2.*sinHalf*cosHalf;
+  G4double cosStep = 1. - 2.*sinHalf*sinHalf;
+  G4double rext    = rmax/cosHalf;
+
+  // bounding envelope for full cylinder consists of two polygons,
+  // in other cases it is a sequence of quadrilaterals
+  if (rmin == 0 && dphi == twopi)
+  {
+    G4double sinCur = sinHalf;
+    G4double cosCur = cosHalf;
+
+    G4ThreeVectorList baseA(NSTEPS),baseB(NSTEPS);
+    for (G4int k=0; k<NSTEPS; ++k)
+    {
+      baseA[k].set(rext*cosCur,rext*sinCur,-dz);
+      baseB[k].set(rext*cosCur,rext*sinCur, dz);
+
+      G4double sinTmp = sinCur;
+      sinCur = sinCur*cosStep + cosCur*sinStep;
+      cosCur = cosCur*cosStep - sinTmp*sinStep;
+    }
+    std::vector<const G4ThreeVectorList *> polygons(2);
+    polygons[0] = &baseA;
+    polygons[1] = &baseB;
+    G4BoundingEnvelope benv(bmin,bmax,polygons);
+    exist = benv.CalculateExtent(pAxis,pVoxelLimit,pTransform,pMin,pMax);
+  }
+  else
+  {
+    G4double sinStart = GetSinStartPhi();
+    G4double cosStart = GetCosStartPhi();
+    G4double sinEnd   = GetSinEndPhi();
+    G4double cosEnd   = GetCosEndPhi();
+    G4double sinCur   = sinStart*cosHalf + cosStart*sinHalf;
+    G4double cosCur   = cosStart*cosHalf - sinStart*sinHalf;
+
+    // set quadrilaterals
+    G4ThreeVectorList pols[NSTEPS+2];
+    for (G4int k=0; k<ksteps+2; ++k) pols[k].resize(4);
+    pols[0][0].set(rmin*cosStart,rmin*sinStart, dz);
+    pols[0][1].set(rmin*cosStart,rmin*sinStart,-dz);
+    pols[0][2].set(rmax*cosStart,rmax*sinStart,-dz);
+    pols[0][3].set(rmax*cosStart,rmax*sinStart, dz);
+    for (G4int k=1; k<ksteps+1; ++k)
+    {
+      pols[k][0].set(rmin*cosCur,rmin*sinCur, dz);
+      pols[k][1].set(rmin*cosCur,rmin*sinCur,-dz);
+      pols[k][2].set(rext*cosCur,rext*sinCur,-dz);
+      pols[k][3].set(rext*cosCur,rext*sinCur, dz);
+
+      G4double sinTmp = sinCur;
+      sinCur = sinCur*cosStep + cosCur*sinStep;
+      cosCur = cosCur*cosStep - sinTmp*sinStep;
+    }
+    pols[ksteps+1][0].set(rmin*cosEnd,rmin*sinEnd, dz);
+    pols[ksteps+1][1].set(rmin*cosEnd,rmin*sinEnd,-dz);
+    pols[ksteps+1][2].set(rmax*cosEnd,rmax*sinEnd,-dz);
+    pols[ksteps+1][3].set(rmax*cosEnd,rmax*sinEnd, dz);
+
+    // set envelope and calculate extent
+    std::vector<const G4ThreeVectorList *> polygons;
+    polygons.resize(ksteps+2);
+    for (G4int k=0; k<ksteps+2; ++k) polygons[k] = &pols[k];
+    G4BoundingEnvelope benv(bmin,bmax,polygons);
+    exist = benv.CalculateExtent(pAxis,pVoxelLimit,pTransform,pMin,pMax);
+  }
+  return exist;
+}
+
+///////////////////////////////////////////////////////////////////////////
+//
+// Return whether point inside/outside/on surface
+
+EInside G4Tubs::Inside( const G4ThreeVector& p ) const
+{
+  G4double r2,pPhi,tolRMin,tolRMax;
+  EInside in = kOutside ;
+
+  if (std::fabs(p.z()) <= fDz - halfCarTolerance)
+  {
+    r2 = p.x()*p.x() + p.y()*p.y() ;
+
+    if (fRMin) { tolRMin = fRMin + halfRadTolerance ; }
+    else       { tolRMin = 0 ; }
+
+    tolRMax = fRMax - halfRadTolerance ;
+      
+    if ((r2 >= tolRMin*tolRMin) && (r2 <= tolRMax*tolRMax))
+    {
+      if ( fPhiFullTube )
+      {
+        in = kInside ;
+      }
+      else
+      {
+        // Try inner tolerant phi boundaries (=>inside)
+        // if not inside, try outer tolerant phi boundaries
+
+        if ( (tolRMin==0) && (std::fabs(p.x())<=halfCarTolerance)
+                          && (std::fabs(p.y())<=halfCarTolerance) )
+        {
+          in=kSurface;
+        }
+        else
+        {
+          pPhi = std::atan2(p.y(),p.x()) ;
+          if ( pPhi < -halfAngTolerance )  { pPhi += twopi; } // 0<=pPhi<2pi
+
+          if ( fSPhi >= 0 )
+          {
+            if ( (std::fabs(pPhi) < halfAngTolerance)
+              && (std::fabs(fSPhi + fDPhi - twopi) < halfAngTolerance) )
+            { 
+              pPhi += twopi ; // 0 <= pPhi < 2pi
+            }
+            if ( (pPhi >= fSPhi + halfAngTolerance)
+              && (pPhi <= fSPhi + fDPhi - halfAngTolerance) )
+            {
+              in = kInside ;
+            }
+            else if ( (pPhi >= fSPhi - halfAngTolerance)
+                   && (pPhi <= fSPhi + fDPhi + halfAngTolerance) )
+            {
+              in = kSurface ;
+            }
+          }
+          else  // fSPhi < 0
+          {
+            if ( (pPhi <= fSPhi + twopi - halfAngTolerance)
+              && (pPhi >= fSPhi + fDPhi  + halfAngTolerance) ) {;} //kOutside
+            else if ( (pPhi <= fSPhi + twopi + halfAngTolerance)
+                   && (pPhi >= fSPhi + fDPhi  - halfAngTolerance) )
+            {
+              in = kSurface ;
+            }
+            else
+            {
+              in = kInside ;
+            }
+          }
+        }                    
+      }
+    }
+    else  // Try generous boundaries
+    {
+      tolRMin = fRMin - halfRadTolerance ;
+      tolRMax = fRMax + halfRadTolerance ;
+
+      if ( tolRMin < 0 )  { tolRMin = 0; }
+
+      if ( (r2 >= tolRMin*tolRMin) && (r2 <= tolRMax*tolRMax) )
+      {
+        if (fPhiFullTube || (r2 <=halfRadTolerance*halfRadTolerance) )
+        {                        // Continuous in phi or on z-axis
+          in = kSurface ;
+        }
+        else // Try outer tolerant phi boundaries only
+        {
+          pPhi = std::atan2(p.y(),p.x()) ;
+
+          if ( pPhi < -halfAngTolerance)  { pPhi += twopi; } // 0<=pPhi<2pi
+          if ( fSPhi >= 0 )
+          {
+            if ( (std::fabs(pPhi) < halfAngTolerance)
+              && (std::fabs(fSPhi + fDPhi - twopi) < halfAngTolerance) )
+            { 
+              pPhi += twopi ; // 0 <= pPhi < 2pi
+            }
+            if ( (pPhi >= fSPhi - halfAngTolerance)
+              && (pPhi <= fSPhi + fDPhi + halfAngTolerance) )
+            {
+              in = kSurface ;
+            }
+          }
+          else  // fSPhi < 0
+          {
+            if ( (pPhi <= fSPhi + twopi - halfAngTolerance)
+              && (pPhi >= fSPhi + fDPhi + halfAngTolerance) ) {;} // kOutside
+            else
+            {
+              in = kSurface ;
+            }
+          }
+        }
+      }
+    }
+  }
+  else if (std::fabs(p.z()) <= fDz + halfCarTolerance)
+  {                                          // Check within tolerant r limits
+    r2      = p.x()*p.x() + p.y()*p.y() ;
+    tolRMin = fRMin - halfRadTolerance ;
+    tolRMax = fRMax + halfRadTolerance ;
+
+    if ( tolRMin < 0 )  { tolRMin = 0; }
+
+    if ( (r2 >= tolRMin*tolRMin) && (r2 <= tolRMax*tolRMax) )
+    {
+      if (fPhiFullTube || (r2 <=halfRadTolerance*halfRadTolerance))
+      {                        // Continuous in phi or on z-axis
+        in = kSurface ;
+      }
+      else // Try outer tolerant phi boundaries
+      {
+        pPhi = std::atan2(p.y(),p.x()) ;
+
+        if ( pPhi < -halfAngTolerance )  { pPhi += twopi; }  // 0<=pPhi<2pi
+        if ( fSPhi >= 0 )
+        {
+          if ( (std::fabs(pPhi) < halfAngTolerance)
+            && (std::fabs(fSPhi + fDPhi - twopi) < halfAngTolerance) )
+          { 
+            pPhi += twopi ; // 0 <= pPhi < 2pi
+          }
+          if ( (pPhi >= fSPhi - halfAngTolerance)
+            && (pPhi <= fSPhi + fDPhi + halfAngTolerance) )
+          {
+            in = kSurface;
+          }
+        }
+        else  // fSPhi < 0
+        {
+          if ( (pPhi <= fSPhi + twopi - halfAngTolerance)
+            && (pPhi >= fSPhi + fDPhi  + halfAngTolerance) ) {;}
+          else
+          {
+            in = kSurface ;
+          }
+        }      
+      }
+    }
+  }
+  return in;
+}
+
+///////////////////////////////////////////////////////////////////////////
+//
+// Return unit normal of surface closest to p
+// - note if point on z axis, ignore phi divided sides
+// - unsafe if point close to z axis a rmin=0 - no explicit checks
+
+G4ThreeVector G4Tubs::SurfaceNormal( const G4ThreeVector& p ) const
+{
+  G4int noSurfaces = 0;
+  G4double rho, pPhi;
+  G4double distZ, distRMin, distRMax;
+  G4double distSPhi = kInfinity, distEPhi = kInfinity;
+
+  G4ThreeVector norm, sumnorm(0.,0.,0.);
+  G4ThreeVector nZ = G4ThreeVector(0, 0, 1.0);
+  G4ThreeVector nR, nPs, nPe;
+
+  rho = std::sqrt(p.x()*p.x() + p.y()*p.y());
+
+  distRMin = std::fabs(rho - fRMin);
+  distRMax = std::fabs(rho - fRMax);
+  distZ    = std::fabs(std::fabs(p.z()) - fDz);
+
+  if (!fPhiFullTube)    // Protected against (0,0,z) 
+  {
+    if ( rho > halfCarTolerance )
+    {
+      pPhi = std::atan2(p.y(),p.x());
+    
+      if(pPhi  < fSPhi- halfCarTolerance)           { pPhi += twopi; }
+      else if(pPhi > fSPhi+fDPhi+ halfCarTolerance) { pPhi -= twopi; }
+
+      distSPhi = std::fabs(pPhi - fSPhi);       
+      distEPhi = std::fabs(pPhi - fSPhi - fDPhi); 
+    }
+    else if( !fRMin )
+    {
+      distSPhi = 0.; 
+      distEPhi = 0.; 
+    }
+    nPs = G4ThreeVector(std::sin(fSPhi),-std::cos(fSPhi),0);
+    nPe = G4ThreeVector(-std::sin(fSPhi+fDPhi),std::cos(fSPhi+fDPhi),0);
+  }
+  if ( rho > halfCarTolerance ) { nR = G4ThreeVector(p.x()/rho,p.y()/rho,0); }
+
+  if( distRMax <= halfCarTolerance )
+  {
+    noSurfaces ++;
+    sumnorm += nR;
+  }
+  if( fRMin && (distRMin <= halfCarTolerance) )
+  {
+    noSurfaces ++;
+    sumnorm -= nR;
+  }
+  if( fDPhi < twopi )   
+  {
+    if (distSPhi <= halfAngTolerance)  
+    {
+      noSurfaces ++;
+      sumnorm += nPs;
+    }
+    if (distEPhi <= halfAngTolerance)  
+    {
+      noSurfaces ++;
+      sumnorm += nPe;
+    }
+  }
+  if (distZ <= halfCarTolerance)  
+  {
+    noSurfaces ++;
+    if ( p.z() >= 0.)  { sumnorm += nZ; }
+    else               { sumnorm -= nZ; }
+  }
+  if ( noSurfaces == 0 )
+  {
+#ifdef G4CSGDEBUG
+    G4Exception("G4Tubs::SurfaceNormal(p)", "GeomSolids1002",
+                JustWarning, "Point p is not on surface !?" );
+    G4int oldprc = G4cout.precision(20);
+    G4cout<< "G4Tubs::SN ( "<<p.x()<<", "<<p.y()<<", "<<p.z()<<" ); "
+          << G4endl << G4endl;
+    G4cout.precision(oldprc) ;
+#endif 
+     norm = ApproxSurfaceNormal(p);
+  }
+  else if ( noSurfaces == 1 )  { norm = sumnorm; }
+  else                         { norm = sumnorm.unit(); }
+
+  return norm;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Algorithm for SurfaceNormal() following the original specification
+// for points not on the surface
+
+G4ThreeVector G4Tubs::ApproxSurfaceNormal( const G4ThreeVector& p ) const
+{
+  ENorm side ;
+  G4ThreeVector norm ;
+  G4double rho, phi ;
+  G4double distZ, distRMin, distRMax, distSPhi, distEPhi, distMin ;
+
+  rho = std::sqrt(p.x()*p.x() + p.y()*p.y()) ;
+
+  distRMin = std::fabs(rho - fRMin) ;
+  distRMax = std::fabs(rho - fRMax) ;
+  distZ    = std::fabs(std::fabs(p.z()) - fDz) ;
+
+  if (distRMin < distRMax) // First minimum
+  {
+    if ( distZ < distRMin )
+    {
+       distMin = distZ ;
+       side    = kNZ ;
+    }
+    else
+    {
+      distMin = distRMin ;
+      side    = kNRMin   ;
+    }
+  }
+  else
+  {
+    if ( distZ < distRMax )
+    {
+      distMin = distZ ;
+      side    = kNZ   ;
+    }
+    else
+    {
+      distMin = distRMax ;
+      side    = kNRMax   ;
+    }
+  }   
+  if (!fPhiFullTube  &&  rho ) // Protected against (0,0,z) 
+  {
+    phi = std::atan2(p.y(),p.x()) ;
+
+    if ( phi < 0 )  { phi += twopi; }
+
+    if ( fSPhi < 0 )
+    {
+      distSPhi = std::fabs(phi - (fSPhi + twopi))*rho ;
+    }
+    else
+    {
+      distSPhi = std::fabs(phi - fSPhi)*rho ;
+    }
+    distEPhi = std::fabs(phi - fSPhi - fDPhi)*rho ;
+                                      
+    if (distSPhi < distEPhi) // Find new minimum
+    {
+      if ( distSPhi < distMin )
+      {
+        side = kNSPhi ;
+      }
+    }
+    else
+    {
+      if ( distEPhi < distMin )
+      {
+        side = kNEPhi ;
+      }
+    }
+  }    
+  switch ( side )
+  {
+    case kNRMin : // Inner radius
+    {                      
+      norm = G4ThreeVector(-p.x()/rho, -p.y()/rho, 0) ;
+      break ;
+    }
+    case kNRMax : // Outer radius
+    {                  
+      norm = G4ThreeVector(p.x()/rho, p.y()/rho, 0) ;
+      break ;
+    }
+    case kNZ :    // + or - dz
+    {                              
+      if ( p.z() > 0 )  { norm = G4ThreeVector(0,0,1) ; }
+      else              { norm = G4ThreeVector(0,0,-1); }
+      break ;
+    }
+    case kNSPhi:
+    {
+      norm = G4ThreeVector(std::sin(fSPhi), -std::cos(fSPhi), 0) ;
+      break ;
+    }
+    case kNEPhi:
+    {
+      norm = G4ThreeVector(-std::sin(fSPhi+fDPhi), std::cos(fSPhi+fDPhi), 0) ;
+      break;
+    }
+    default:      // Should never reach this case ...
+    {
+      DumpInfo();
+      G4Exception("G4Tubs::ApproxSurfaceNormal()",
+                  "GeomSolids1002", JustWarning,
+                  "Undefined side for valid surface normal to solid.");
+      break ;
+    }    
+  }                
+  return norm;
+}
+
+////////////////////////////////////////////////////////////////////
+//
+//
+// Calculate distance to shape from outside, along normalised vector
+// - return kInfinity if no intersection, or intersection distance <= tolerance
+//
+// - Compute the intersection with the z planes 
+//        - if at valid r, phi, return
+//
+// -> If point is outer outer radius, compute intersection with rmax
+//        - if at valid phi,z return
+//
+// -> Compute intersection with inner radius, taking largest +ve root
+//        - if valid (in z,phi), save intersction
+//
+//    -> If phi segmented, compute intersections with phi half planes
+//        - return smallest of valid phi intersections and
+//          inner radius intersection
+//
+// NOTE:
+// - 'if valid' implies tolerant checking of intersection points
+
+G4double G4Tubs::DistanceToIn( const G4ThreeVector& p,
+                               const G4ThreeVector& v  ) const
+{
+  G4double snxt = kInfinity ;      // snxt = default return value
+  G4double tolORMin2, tolIRMax2 ;  // 'generous' radii squared
+  G4double tolORMax2, tolIRMin2, tolODz, tolIDz ;
+  const G4double dRmax = 100.*fRMax;
+
+  // Intersection point variables
+  //
+  G4double Dist, sd, xi, yi, zi, rho2, inum, iden, cosPsi, Comp ;
+  G4double t1, t2, t3, b, c, d ;     // Quadratic solver variables 
+  
+  // Calculate tolerant rmin and rmax
+
+  if (fRMin > kRadTolerance)
+  {
+    tolORMin2 = (fRMin - halfRadTolerance)*(fRMin - halfRadTolerance) ;
+    tolIRMin2 = (fRMin + halfRadTolerance)*(fRMin + halfRadTolerance) ;
+  }
+  else
+  {
+    tolORMin2 = 0.0 ;
+    tolIRMin2 = 0.0 ;
+  }
+  tolORMax2 = (fRMax + halfRadTolerance)*(fRMax + halfRadTolerance) ;
+  tolIRMax2 = (fRMax - halfRadTolerance)*(fRMax - halfRadTolerance) ;
+
+  // Intersection with Z surfaces
+
+  tolIDz = fDz - halfCarTolerance ;
+  tolODz = fDz + halfCarTolerance ;
+
+  if (std::fabs(p.z()) >= tolIDz)
+  {
+    if ( p.z()*v.z() < 0 )    // at +Z going in -Z or visa versa
+    {
+      sd = (std::fabs(p.z()) - fDz)/std::fabs(v.z()) ;  // Z intersect distance
+
+      if(sd < 0.0)  { sd = 0.0; }
+
+      xi   = p.x() + sd*v.x() ;                // Intersection coords
+      yi   = p.y() + sd*v.y() ;
+      rho2 = xi*xi + yi*yi ;
+
+      // Check validity of intersection
+
+      if ((tolIRMin2 <= rho2) && (rho2 <= tolIRMax2))
+      {
+        if (!fPhiFullTube && rho2)
+        {
+          // Psi = angle made with central (average) phi of shape
+          //
+          inum   = xi*cosCPhi + yi*sinCPhi ;
+          iden   = std::sqrt(rho2) ;
+          cosPsi = inum/iden ;
+          if (cosPsi >= cosHDPhiIT)  { return sd ; }
+        }
+        else
+        {
+          return sd ;
+        }
+      }
+    }
+    else
+    {
+      if ( snxt<halfCarTolerance )  { snxt=0; }
+      return snxt ;  // On/outside extent, and heading away
+                     // -> cannot intersect
+    }
+  }
+
+  // -> Can not intersect z surfaces
+  //
+  // Intersection with rmax (possible return) and rmin (must also check phi)
+  //
+  // Intersection point (xi,yi,zi) on line x=p.x+t*v.x etc.
+  //
+  // Intersects with x^2+y^2=R^2
+  //
+  // Hence (v.x^2+v.y^2)t^2+ 2t(p.x*v.x+p.y*v.y)+p.x^2+p.y^2-R^2=0
+  //            t1                t2                t3
+
+  t1 = 1.0 - v.z()*v.z() ;
+  t2 = p.x()*v.x() + p.y()*v.y() ;
+  t3 = p.x()*p.x() + p.y()*p.y() ;
+
+  if ( t1 > 0 )        // Check not || to z axis
+  {
+    b = t2/t1 ;
+    c = t3 - fRMax*fRMax ;
+    if ((t3 >= tolORMax2) && (t2<0))   // This also handles the tangent case
+    {
+      // Try outer cylinder intersection
+      //          c=(t3-fRMax*fRMax)/t1;
+
+      c /= t1 ;
+      d = b*b - c ;
+
+      if (d >= 0)  // If real root
+      {
+        sd = c/(-b+std::sqrt(d));
+        if (sd >= 0)  // If 'forwards'
+        {
+          if ( sd>dRmax ) // Avoid rounding errors due to precision issues on
+          {               // 64 bits systems. Split long distances and recompute
+            G4double fTerm = sd-std::fmod(sd,dRmax);
+            sd = fTerm + DistanceToIn(p+fTerm*v,v);
+          } 
+          // Check z intersection
+          //
+          zi = p.z() + sd*v.z() ;
+          if (std::fabs(zi)<=tolODz)
+          {
+            // Z ok. Check phi intersection if reqd
+            //
+            if (fPhiFullTube)
+            {
+              return sd ;
+            }
+            else
+            {
+              xi     = p.x() + sd*v.x() ;
+              yi     = p.y() + sd*v.y() ;
+              cosPsi = (xi*cosCPhi + yi*sinCPhi)/fRMax ;
+              if (cosPsi >= cosHDPhiIT)  { return sd ; }
+            }
+          }  //  end if std::fabs(zi)
+        }    //  end if (sd>=0)
+      }      //  end if (d>=0)
+    }        //  end if (r>=fRMax)
+    else 
+    {
+      // Inside outer radius :
+      // check not inside, and heading through tubs (-> 0 to in)
+
+      if ((t3 > tolIRMin2) && (t2 < 0) && (std::fabs(p.z()) <= tolIDz))
+      {
+        // Inside both radii, delta r -ve, inside z extent
+
+        if (!fPhiFullTube)
+        {
+          inum   = p.x()*cosCPhi + p.y()*sinCPhi ;
+          iden   = std::sqrt(t3) ;
+          cosPsi = inum/iden ;
+          if (cosPsi >= cosHDPhiIT)
+          {
+            // In the old version, the small negative tangent for the point
+            // on surface was not taken in account, and returning 0.0 ...
+            // New version: check the tangent for the point on surface and 
+            // if no intersection, return kInfinity, if intersection instead
+            // return sd.
+            //
+            c = t3-fRMax*fRMax; 
+            if ( c<=0.0 )
+            {
+              return 0.0;
+            }
+            else
+            {
+              c = c/t1 ;
+              d = b*b-c;
+              if ( d>=0.0 )
+              {
+                snxt = c/(-b+std::sqrt(d)); // using safe solution
+                                            // for quadratic equation 
+                if ( snxt < halfCarTolerance ) { snxt=0; }
+                return snxt ;
+              }      
+              else
+              {
+                return kInfinity;
+              }
+            }
+          } 
+        }
+        else
+        {   
+          // In the old version, the small negative tangent for the point
+          // on surface was not taken in account, and returning 0.0 ...
+          // New version: check the tangent for the point on surface and 
+          // if no intersection, return kInfinity, if intersection instead
+          // return sd.
+          //
+          c = t3 - fRMax*fRMax; 
+          if ( c<=0.0 )
+          {
+            return 0.0;
+          }
+          else
+          {
+            c = c/t1 ;
+            d = b*b-c;
+            if ( d>=0.0 )
+            {
+              snxt= c/(-b+std::sqrt(d)); // using safe solution
+                                         // for quadratic equation 
+              if ( snxt < halfCarTolerance ) { snxt=0; }
+              return snxt ;
+            }      
+            else
+            {
+              return kInfinity;
+            }
+          }
+        } // end if   (!fPhiFullTube)
+      }   // end if   (t3>tolIRMin2)
+    }     // end if   (Inside Outer Radius) 
+    if ( fRMin )    // Try inner cylinder intersection
+    {
+      c = (t3 - fRMin*fRMin)/t1 ;
+      d = b*b - c ;
+      if ( d >= 0.0 )  // If real root
+      {
+        // Always want 2nd root - we are outside and know rmax Hit was bad
+        // - If on surface of rmin also need farthest root
+
+        sd =( b > 0. )? c/(-b - std::sqrt(d)) : (-b + std::sqrt(d));
+        if (sd >= -halfCarTolerance)  // check forwards
+        {
+          // Check z intersection
+          //
+          if(sd < 0.0)  { sd = 0.0; }
+          if ( sd>dRmax ) // Avoid rounding errors due to precision issues seen
+          {               // 64 bits systems. Split long distances and recompute
+            G4double fTerm = sd-std::fmod(sd,dRmax);
+            sd = fTerm + DistanceToIn(p+fTerm*v,v);
+          } 
+          zi = p.z() + sd*v.z() ;
+          if (std::fabs(zi) <= tolODz)
+          {
+            // Z ok. Check phi
+            //
+            if ( fPhiFullTube )
+            {
+              return sd ; 
+            }
+            else
+            {
+              xi     = p.x() + sd*v.x() ;
+              yi     = p.y() + sd*v.y() ;
+              cosPsi = (xi*cosCPhi + yi*sinCPhi)/fRMin ;
+              if (cosPsi >= cosHDPhiIT)
+              {
+                // Good inner radius isect
+                // - but earlier phi isect still possible
+
+                snxt = sd ;
+              }
+            }
+          }        //    end if std::fabs(zi)
+        }          //    end if (sd>=0)
+      }            //    end if (d>=0)
+    }              //    end if (fRMin)
+  }
+
+  // Phi segment intersection
+  //
+  // o Tolerant of points inside phi planes by up to kCarTolerance*0.5
+  //
+  // o NOTE: Large duplication of code between sphi & ephi checks
+  //         -> only diffs: sphi -> ephi, Comp -> -Comp and half-plane
+  //            intersection check <=0 -> >=0
+  //         -> use some form of loop Construct ?
+  //
+  if ( !fPhiFullTube )
+  {
+    // First phi surface (Starting phi)
+    //
+    Comp    = v.x()*sinSPhi - v.y()*cosSPhi ;
+                    
+    if ( Comp < 0 )  // Component in outwards normal dirn
+    {
+      Dist = (p.y()*cosSPhi - p.x()*sinSPhi) ;
+
+      if ( Dist < halfCarTolerance )
+      {
+        sd = Dist/Comp ;
+
+        if (sd < snxt)
+        {
+          if ( sd < 0 )  { sd = 0.0; }
+          zi = p.z() + sd*v.z() ;
+          if ( std::fabs(zi) <= tolODz )
+          {
+            xi   = p.x() + sd*v.x() ;
+            yi   = p.y() + sd*v.y() ;
+            rho2 = xi*xi + yi*yi ;
+
+            if ( ( (rho2 >= tolIRMin2) && (rho2 <= tolIRMax2) )
+              || ( (rho2 >  tolORMin2) && (rho2 <  tolIRMin2)
+                && ( v.y()*cosSPhi - v.x()*sinSPhi >  0 )
+                && ( v.x()*cosSPhi + v.y()*sinSPhi >= 0 )     )
+              || ( (rho2 > tolIRMax2) && (rho2 < tolORMax2)
+                && (v.y()*cosSPhi - v.x()*sinSPhi > 0)
+                && (v.x()*cosSPhi + v.y()*sinSPhi < 0) )    )
+            {
+              // z and r intersections good
+              // - check intersecting with correct half-plane
+              //
+              if ((yi*cosCPhi-xi*sinCPhi) <= halfCarTolerance) { snxt = sd; }
+            }
+          }
+        }
+      }    
+    }
+      
+    // Second phi surface (Ending phi)
+
+    Comp    = -(v.x()*sinEPhi - v.y()*cosEPhi) ;
+        
+    if (Comp < 0 )  // Component in outwards normal dirn
+    {
+      Dist = -(p.y()*cosEPhi - p.x()*sinEPhi) ;
+
+      if ( Dist < halfCarTolerance )
+      {
+        sd = Dist/Comp ;
+
+        if (sd < snxt)
+        {
+          if ( sd < 0 )  { sd = 0; }
+          zi = p.z() + sd*v.z() ;
+          if ( std::fabs(zi) <= tolODz )
+          {
+            xi   = p.x() + sd*v.x() ;
+            yi   = p.y() + sd*v.y() ;
+            rho2 = xi*xi + yi*yi ;
+            if ( ( (rho2 >= tolIRMin2) && (rho2 <= tolIRMax2) )
+                || ( (rho2 > tolORMin2)  && (rho2 < tolIRMin2)
+                  && (v.x()*sinEPhi - v.y()*cosEPhi >  0)
+                  && (v.x()*cosEPhi + v.y()*sinEPhi >= 0) )
+                || ( (rho2 > tolIRMax2) && (rho2 < tolORMax2)
+                  && (v.x()*sinEPhi - v.y()*cosEPhi > 0)
+                  && (v.x()*cosEPhi + v.y()*sinEPhi < 0) ) )
+            {
+              // z and r intersections good
+              // - check intersecting with correct half-plane
+              //
+              if ( (yi*cosCPhi-xi*sinCPhi) >= 0 ) { snxt = sd; }
+            }                         //?? >=-halfCarTolerance
+          }
+        }
+      }
+    }         //  Comp < 0
+  }           //  !fPhiFullTube 
+  if ( snxt<halfCarTolerance )  { snxt=0; }
+  return snxt ;
+}
+ 
+//////////////////////////////////////////////////////////////////
+//
+// Calculate distance to shape from outside, along normalised vector
+// - return kInfinity if no intersection, or intersection distance <= tolerance
+//
+// - Compute the intersection with the z planes 
+//        - if at valid r, phi, return
+//
+// -> If point is outer outer radius, compute intersection with rmax
+//        - if at valid phi,z return
+//
+// -> Compute intersection with inner radius, taking largest +ve root
+//        - if valid (in z,phi), save intersction
+//
+//    -> If phi segmented, compute intersections with phi half planes
+//        - return smallest of valid phi intersections and
+//          inner radius intersection
+//
+// NOTE:
+// - Precalculations for phi trigonometry are Done `just in time'
+// - `if valid' implies tolerant checking of intersection points
+//   Calculate distance (<= actual) to closest surface of shape from outside
+// - Calculate distance to z, radial planes
+// - Only to phi planes if outside phi extent
+// - Return 0 if point inside
+
+G4double G4Tubs::DistanceToIn( const G4ThreeVector& p ) const
+{
+  G4double safe=0.0, rho, safe1, safe2, safe3 ;
+  G4double safePhi, cosPsi ;
+
+  rho   = std::sqrt(p.x()*p.x() + p.y()*p.y()) ;
+  safe1 = fRMin - rho ;
+  safe2 = rho - fRMax ;
+  safe3 = std::fabs(p.z()) - fDz ;
+
+  if ( safe1 > safe2 ) { safe = safe1; }
+  else                 { safe = safe2; }
+  if ( safe3 > safe )  { safe = safe3; }
+
+  if ( (!fPhiFullTube) && (rho) )
+  {
+    // Psi=angle from central phi to point
+    //
+    cosPsi = (p.x()*cosCPhi + p.y()*sinCPhi)/rho ;
+    
+    if ( cosPsi < std::cos(fDPhi*0.5) )
+    {
+      // Point lies outside phi range
+
+      if ( (p.y()*cosCPhi - p.x()*sinCPhi) <= 0 )
+      {
+        safePhi = std::fabs(p.x()*sinSPhi - p.y()*cosSPhi) ;
+      }
+      else
+      {
+        safePhi = std::fabs(p.x()*sinEPhi - p.y()*cosEPhi) ;
+      }
+      if ( safePhi > safe )  { safe = safePhi; }
+    }
+  }
+  if ( safe < 0 )  { safe = 0; }
+  return safe ;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Calculate distance to surface of shape from `inside', allowing for tolerance
+// - Only Calc rmax intersection if no valid rmin intersection
+
+G4double G4Tubs::DistanceToOut( const G4ThreeVector& p,
+                                const G4ThreeVector& v,
+                                const G4bool calcNorm,
+                                      G4bool *validNorm,
+                                      G4ThreeVector *n    ) const
+{  
+  ESide side=kNull , sider=kNull, sidephi=kNull ;
+  G4double snxt, srd=kInfinity, sphi=kInfinity, pdist ;
+  G4double deltaR, t1, t2, t3, b, c, d2, roMin2 ;
+
+  // Vars for phi intersection:
+
+  G4double pDistS, compS, pDistE, compE, sphi2, xi, yi, vphi, roi2 ;
+ 
+  // Z plane intersection
+
+  if (v.z() > 0 )
+  {
+    pdist = fDz - p.z() ;
+    if ( pdist > halfCarTolerance )
+    {
+      snxt = pdist/v.z() ;
+      side = kPZ ;
+    }
+    else
+    {
+      if (calcNorm)
+      {
+        *n         = G4ThreeVector(0,0,1) ;
+        *validNorm = true ;
+      }
+      return snxt = 0 ;
+    }
+  }
+  else if ( v.z() < 0 )
+  {
+    pdist = fDz + p.z() ;
+
+    if ( pdist > halfCarTolerance )
+    {
+      snxt = -pdist/v.z() ;
+      side = kMZ ;
+    }
+    else
+    {
+      if (calcNorm)
+      {
+        *n         = G4ThreeVector(0,0,-1) ;
+        *validNorm = true ;
+      }
+      return snxt = 0.0 ;
+    }
+  }
+  else
+  {
+    snxt = kInfinity ;    // Travel perpendicular to z axis
+    side = kNull;
+  }
+
+  // Radial Intersections
+  //
+  // Find intersection with cylinders at rmax/rmin
+  // Intersection point (xi,yi,zi) on line x=p.x+t*v.x etc.
+  //
+  // Intersects with x^2+y^2=R^2
+  //
+  // Hence (v.x^2+v.y^2)t^2+ 2t(p.x*v.x+p.y*v.y)+p.x^2+p.y^2-R^2=0
+  //
+  //            t1                t2                    t3
+
+  t1   = 1.0 - v.z()*v.z() ;      // since v normalised
+  t2   = p.x()*v.x() + p.y()*v.y() ;
+  t3   = p.x()*p.x() + p.y()*p.y() ;
+
+  if ( snxt > 10*(fDz+fRMax) )  { roi2 = 2*fRMax*fRMax; }
+  else  { roi2 = snxt*snxt*t1 + 2*snxt*t2 + t3; }        // radius^2 on +-fDz
+
+  if ( t1 > 0 ) // Check not parallel
+  {
+    // Calculate srd, r exit distance
+     
+    if ( (t2 >= 0.0) && (roi2 > fRMax*(fRMax + kRadTolerance)) )
+    {
+      // Delta r not negative => leaving via rmax
+
+      deltaR = t3 - fRMax*fRMax ;
+
+      // NOTE: Should use rho-fRMax<-kRadTolerance*0.5
+      // - avoid sqrt for efficiency
+
+      if ( deltaR < -kRadTolerance*fRMax )
+      {
+        b     = t2/t1 ;
+        c     = deltaR/t1 ;
+        d2    = b*b-c;
+        if( d2 >= 0 ) { srd = c/( -b - std::sqrt(d2)); }
+        else          { srd = 0.; }
+        sider = kRMax ;
+      }
+      else
+      {
+        // On tolerant boundary & heading outwards (or perpendicular to)
+        // outer radial surface -> leaving immediately
+
+        if ( calcNorm ) 
+        {
+          *n         = G4ThreeVector(p.x(),p.y(),0) ;
+		  n->setMag(1) ;
+          *validNorm = true ;
+        }
+        return snxt = 0 ; // Leaving by rmax immediately
+      }
+    }             
+    else if ( t2 < 0. ) // i.e.  t2 < 0; Possible rmin intersection
+    {
+      roMin2 = t3 - t2*t2/t1 ; // min ro2 of the plane of movement 
+
+      if ( fRMin && (roMin2 < fRMin*(fRMin - kRadTolerance)) )
+      {
+        deltaR = t3 - fRMin*fRMin ;
+        b      = t2/t1 ;
+        c      = deltaR/t1 ;
+        d2     = b*b - c ;
+
+        if ( d2 >= 0 )   // Leaving via rmin
+        {
+          // NOTE: SHould use rho-rmin>kRadTolerance*0.5
+          // - avoid sqrt for efficiency
+
+          if (deltaR > kRadTolerance*fRMin)
+          {
+            srd = c/(-b+std::sqrt(d2)); 
+            sider = kRMin ;
+          }
+          else
+          {
+            if ( calcNorm ) { *validNorm = false; }  // Concave side
+            return snxt = 0.0;
+          }
+        }
+        else    // No rmin intersect -> must be rmax intersect
+        {
+          deltaR = t3 - fRMax*fRMax ;
+          c     = deltaR/t1 ;
+          d2    = b*b-c;
+          if( d2 >=0. )
+          {
+            srd     = -b + std::sqrt(d2) ;
+            sider  = kRMax ;
+          }
+          else // Case: On the border+t2<kRadTolerance
+               //       (v is perpendicular to the surface)
+          {
+            if (calcNorm)
+            {
+              *n = G4ThreeVector(p.x(),p.y(),0) ;
+			  n->setMag(1) ;
+              *validNorm = true ;
+            }
+            return snxt = 0.0;
+          }
+        }
+      }
+      else if ( roi2 > fRMax*(fRMax + kRadTolerance) )
+           // No rmin intersect -> must be rmax intersect
+      {
+        deltaR = t3 - fRMax*fRMax ;
+        b      = t2/t1 ;
+        c      = deltaR/t1;
+        d2     = b*b-c;
+        if( d2 >= 0 )
+        {
+          srd     = -b + std::sqrt(d2) ;
+          sider  = kRMax ;
+        }
+        else // Case: On the border+t2<kRadTolerance
+             //       (v is perpendicular to the surface)
+        {
+          if (calcNorm)
+          {
+            *n = G4ThreeVector(p.x(),p.y(),0) ;
+			n->setMag(1) ;
+            *validNorm = true ;
+          }
+          return snxt = 0.0;
+        }
+      }
+    }
+    
+    // Phi Intersection
+
+    if ( !fPhiFullTube )
+    {
+      // add angle calculation with correction 
+      // of the difference in domain of atan2 and Sphi
+      //
+      vphi = std::atan2(v.y(),v.x()) ;
+     
+      if ( vphi < fSPhi - halfAngTolerance  )             { vphi += twopi; }
+      else if ( vphi > fSPhi + fDPhi + halfAngTolerance ) { vphi -= twopi; }
+
+
+      if ( p.x() || p.y() )  // Check if on z axis (rho not needed later)
+      {
+        // pDist -ve when inside
+
+        pDistS = p.x()*sinSPhi - p.y()*cosSPhi ;
+        pDistE = -p.x()*sinEPhi + p.y()*cosEPhi ;
+
+        // Comp -ve when in direction of outwards normal
+
+        compS   = -sinSPhi*v.x() + cosSPhi*v.y() ;
+        compE   =  sinEPhi*v.x() - cosEPhi*v.y() ;
+       
+        sidephi = kNull;
+        
+        if( ( (fDPhi <= pi) && ( (pDistS <= halfCarTolerance)
+                              && (pDistE <= halfCarTolerance) ) )
+         || ( (fDPhi >  pi) && !((pDistS >  halfCarTolerance)
+                              && (pDistE >  halfCarTolerance) ) )  )
+        {
+          // Inside both phi *full* planes
+          
+          if ( compS < 0 )
+          {
+            sphi = pDistS/compS ;
+            
+            if (sphi >= -halfCarTolerance)
+            {
+              xi = p.x() + sphi*v.x() ;
+              yi = p.y() + sphi*v.y() ;
+              
+              // Check intersecting with correct half-plane
+              // (if not -> no intersect)
+              //
+              if((std::fabs(xi)<=kCarTolerance)&&(std::fabs(yi)<=kCarTolerance))
+              {
+                sidephi = kSPhi;
+                if (((fSPhi-halfAngTolerance)<=vphi)
+                   &&((fSPhi+fDPhi+halfAngTolerance)>=vphi))
+                {
+                  sphi = kInfinity;
+                }
+              }
+              else if ( yi*cosCPhi-xi*sinCPhi >=0 )
+              {
+                sphi = kInfinity ;
+              }
+              else
+              {
+                sidephi = kSPhi ;
+                if ( pDistS > -halfCarTolerance )
+                {
+                  sphi = 0.0 ; // Leave by sphi immediately
+                }    
+              }       
+            }
+            else
+            {
+              sphi = kInfinity ;
+            }
+          }
+          else
+          {
+            sphi = kInfinity ;
+          }
+
+          if ( compE < 0 )
+          {
+            sphi2 = pDistE/compE ;
+            
+            // Only check further if < starting phi intersection
+            //
+            if ( (sphi2 > -halfCarTolerance) && (sphi2 < sphi) )
+            {
+              xi = p.x() + sphi2*v.x() ;
+              yi = p.y() + sphi2*v.y() ;
+              
+              if((std::fabs(xi)<=kCarTolerance)&&(std::fabs(yi)<=kCarTolerance))
+              {
+                // Leaving via ending phi
+                //
+                if( !((fSPhi-halfAngTolerance <= vphi)
+                     &&(fSPhi+fDPhi+halfAngTolerance >= vphi)) )
+                {
+                  sidephi = kEPhi ;
+                  if ( pDistE <= -halfCarTolerance )  { sphi = sphi2 ; }
+                  else                                { sphi = 0.0 ;   }
+                }
+              } 
+              else    // Check intersecting with correct half-plane 
+
+              if ( (yi*cosCPhi-xi*sinCPhi) >= 0)
+              {
+                // Leaving via ending phi
+                //
+                sidephi = kEPhi ;
+                if ( pDistE <= -halfCarTolerance ) { sphi = sphi2 ; }
+                else                               { sphi = 0.0 ;   }
+              }
+            }
+          }
+        }
+        else
+        {
+          sphi = kInfinity ;
+        }
+      }
+      else
+      {
+        // On z axis + travel not || to z axis -> if phi of vector direction
+        // within phi of shape, Step limited by rmax, else Step =0
+               
+        if ( (fSPhi - halfAngTolerance <= vphi)
+           && (vphi <= fSPhi + fDPhi + halfAngTolerance ) )
+        {
+          sphi = kInfinity ;
+        }
+        else
+        {
+          sidephi = kSPhi ; // arbitrary 
+          sphi    = 0.0 ;
+        }
+      }
+      if (sphi < snxt)  // Order intersecttions
+      {
+        snxt = sphi ;
+        side = sidephi ;
+      }
+    }
+    if (srd < snxt)  // Order intersections
+    {
+      snxt = srd ;
+      side = sider ;
+    }
+  }
+  if (calcNorm)
+  {
+    switch(side)
+    {
+      case kRMax:
+        // Note: returned vector not normalised
+        // (divide by fRMax for unit vector)
+        //
+        xi = p.x() + snxt*v.x() ;
+        yi = p.y() + snxt*v.y() ;
+        *n = G4ThreeVector(xi,yi,0) ;
+		n->setMag(1) ;
+        *validNorm = true ;
+        break ;
+
+      case kRMin:
+        *validNorm = false ;  // Rmin is inconvex
+        break ;
+
+      case kSPhi:
+        if ( fDPhi <= pi )
+        {
+          *n         = G4ThreeVector(sinSPhi,-cosSPhi,0) ;
+		  n->setMag(1) ;
+          *validNorm = true ;
+        }
+        else
+        {
+          *validNorm = false ;
+        }
+        break ;
+
+      case kEPhi:
+        if (fDPhi <= pi)
+        {
+          *n = G4ThreeVector(-sinEPhi,cosEPhi,0) ;
+		  n->setMag(1) ;
+          *validNorm = true ;
+        }
+        else
+        {
+          *validNorm = false ;
+        }
+        break ;
+
+      case kPZ:
+        *n         = G4ThreeVector(0,0,1) ;
+        *validNorm = true ;
+        break ;
+
+      case kMZ:
+        *n         = G4ThreeVector(0,0,-1) ;
+        *validNorm = true ;
+        break ;
+
+      default:
+        G4cout << G4endl ;
+        DumpInfo();
+        std::ostringstream message;
+        G4int oldprc = message.precision(16);
+        message << "Undefined side for valid surface normal to solid."
+                << G4endl
+                << "Position:"  << G4endl << G4endl
+                << "p.x() = "   << p.x()/mm << " mm" << G4endl
+                << "p.y() = "   << p.y()/mm << " mm" << G4endl
+                << "p.z() = "   << p.z()/mm << " mm" << G4endl << G4endl
+                << "Direction:" << G4endl << G4endl
+                << "v.x() = "   << v.x() << G4endl
+                << "v.y() = "   << v.y() << G4endl
+                << "v.z() = "   << v.z() << G4endl << G4endl
+                << "Proposed distance :" << G4endl << G4endl
+                << "snxt = "    << snxt/mm << " mm" << G4endl ;
+        message.precision(oldprc) ;
+        G4Exception("G4Tubs::DistanceToOut(p,v,..)", "GeomSolids1002",
+                    JustWarning, message);
+        break ;
+    }
+  }
+  if ( snxt<halfCarTolerance )  { snxt=0 ; }
+
+  return snxt ;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Calculate distance (<=actual) to closest surface of shape from inside
+
+G4double G4Tubs::DistanceToOut( const G4ThreeVector& p ) const
+{
+  G4double safe=0.0, rho, safeR1, safeR2, safeZ, safePhi ;
+  rho = std::sqrt(p.x()*p.x() + p.y()*p.y()) ;
+
+#ifdef G4CSGDEBUG
+  if( Inside(p) == kOutside )
+  {
+    G4int oldprc = G4cout.precision(16) ;
+    G4cout << G4endl ;
+    DumpInfo();
+    G4cout << "Position:"  << G4endl << G4endl ;
+    G4cout << "p.x() = "   << p.x()/mm << " mm" << G4endl ;
+    G4cout << "p.y() = "   << p.y()/mm << " mm" << G4endl ;
+    G4cout << "p.z() = "   << p.z()/mm << " mm" << G4endl << G4endl ;
+    G4cout.precision(oldprc) ;
+    G4Exception("G4Tubs::DistanceToOut(p)", "GeomSolids1002",
+                JustWarning, "Point p is outside !?");
+  }
+#endif
+
+  if ( fRMin )
+  {
+    safeR1 = rho   - fRMin ;
+    safeR2 = fRMax - rho ;
+ 
+    if ( safeR1 < safeR2 ) { safe = safeR1 ; }
+    else                   { safe = safeR2 ; }
+  }
+  else
+  {
+    safe = fRMax - rho ;
+  }
+  safeZ = fDz - std::fabs(p.z()) ;
+
+  if ( safeZ < safe )  { safe = safeZ ; }
+
+  // Check if phi divided, Calc distances closest phi plane
+  //
+  if ( !fPhiFullTube )
+  {
+    if ( p.y()*cosCPhi-p.x()*sinCPhi <= 0 )
+    {
+      safePhi = -(p.x()*sinSPhi - p.y()*cosSPhi) ;
+    }
+    else
+    {
+      safePhi = (p.x()*sinEPhi - p.y()*cosEPhi) ;
+    }
+    if (safePhi < safe)  { safe = safePhi ; }
+  }
+  if ( safe < 0 )  { safe = 0 ; }
+
+  return safe ;  
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Stream object contents to an output stream
+
+G4GeometryType G4Tubs::GetEntityType() const
+{
+  return G4String("G4Tubs");
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Make a clone of the object
+//
+G4VSolid* G4Tubs::Clone() const
+{
+  return new G4Tubs(*this);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Stream object contents to an output stream
+
+std::ostream& G4Tubs::StreamInfo( std::ostream& os ) const
+{
+  G4int oldprc = os.precision(16);
+  os << "-----------------------------------------------------------\n"
+     << "    *** Dump for solid - " << GetName() << " ***\n"
+     << "    ===================================================\n"
+     << " Solid type: G4Tubs\n"
+     << " Parameters: \n"
+     << "    inner radius : " << fRMin/mm << " mm \n"
+     << "    outer radius : " << fRMax/mm << " mm \n"
+     << "    half length Z: " << fDz/mm << " mm \n"
+     << "    starting phi : " << fSPhi/degree << " degrees \n"
+     << "    delta phi    : " << fDPhi/degree << " degrees \n"
+     << "-----------------------------------------------------------\n";
+  os.precision(oldprc);
+
+  return os;
+}
+
+/////////////////////////////////////////////////////////////////////////
+//
+// GetPointOnSurface
+
+G4ThreeVector G4Tubs::GetPointOnSurface() const
+{
+  G4double xRand, yRand, zRand, phi, cosphi, sinphi, chose,
+           aOne, aTwo, aThr, aFou;
+  G4double rRand;
+
+  aOne = 2.*fDz*fDPhi*fRMax;
+  aTwo = 2.*fDz*fDPhi*fRMin;
+  aThr = 0.5*fDPhi*(fRMax*fRMax-fRMin*fRMin);
+  aFou = 2.*fDz*(fRMax-fRMin);
+
+  phi    = G4RandFlat::shoot(fSPhi, fSPhi+fDPhi);
+  cosphi = std::cos(phi);
+  sinphi = std::sin(phi);
+
+  rRand  = GetRadiusInRing(fRMin,fRMax);
+  
+  if( (fSPhi == 0) && (fDPhi == twopi) ) { aFou = 0; }
+  
+  chose  = G4RandFlat::shoot(0.,aOne+aTwo+2.*aThr+2.*aFou);
+
+  if( (chose >=0) && (chose < aOne) )
+  {
+    xRand = fRMax*cosphi;
+    yRand = fRMax*sinphi;
+    zRand = G4RandFlat::shoot(-1.*fDz,fDz);
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+  else if( (chose >= aOne) && (chose < aOne + aTwo) )
+  {
+    xRand = fRMin*cosphi;
+    yRand = fRMin*sinphi;
+    zRand = G4RandFlat::shoot(-1.*fDz,fDz);
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+  else if( (chose >= aOne + aTwo) && (chose < aOne + aTwo + aThr) )
+  {
+    xRand = rRand*cosphi;
+    yRand = rRand*sinphi;
+    zRand = fDz;
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+  else if( (chose >= aOne + aTwo + aThr) && (chose < aOne + aTwo + 2.*aThr) )
+  {
+    xRand = rRand*cosphi;
+    yRand = rRand*sinphi;
+    zRand = -1.*fDz;
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+  else if( (chose >= aOne + aTwo + 2.*aThr)
+        && (chose < aOne + aTwo + 2.*aThr + aFou) )
+  {
+    xRand = rRand*std::cos(fSPhi);
+    yRand = rRand*std::sin(fSPhi);
+    zRand = G4RandFlat::shoot(-1.*fDz,fDz);
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+  else
+  {
+    xRand = rRand*std::cos(fSPhi+fDPhi);
+    yRand = rRand*std::sin(fSPhi+fDPhi);
+    zRand = G4RandFlat::shoot(-1.*fDz,fDz);
+    return G4ThreeVector  (xRand, yRand, zRand);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////
+//
+// Methods for visualisation
+
+void G4Tubs::DescribeYourselfTo ( G4VGraphicsScene& scene ) const 
+{
+  scene.AddSolid (*this) ;
+}
+
+G4Polyhedron* G4Tubs::CreatePolyhedron () const 
+{
+  return new G4PolyhedronTubs (fRMin, fRMax, fDz, fSPhi, fDPhi) ;
+}
+#endif

--- a/src/G4.10.03.p01fixes/G4VDivisionParameterisation.cc
+++ b/src/G4.10.03.p01fixes/G4VDivisionParameterisation.cc
@@ -1,0 +1,214 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: G4VDivisionParameterisation.cc 92625 2015-09-09 12:34:07Z gcosmo $
+//
+// class G4VDivisionParameterisation Implementation file
+//
+// 26.05.03 - P.Arce, Initial version
+// 08.04.04 - I.Hrivnacova, Implemented reflection
+// 21.04.10 - M.Asai, Added gaps
+// --------------------------------------------------------------------
+
+#include "G4VDivisionParameterisation.hh" 
+#include "G4VSolid.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4RotationMatrix.hh"
+#include "G4ReflectedSolid.hh"
+#include "G4GeometryTolerance.hh"
+#include "G4AutoDelete.hh"
+#include "G4AutoLock.hh"
+
+const G4int G4VDivisionParameterisation::verbose = 5;
+G4ThreadLocal G4RotationMatrix* G4VDivisionParameterisation::fRot = 0;
+
+//--------------------------------------------------------------------------
+G4VDivisionParameterisation::
+G4VDivisionParameterisation( EAxis axis, G4int nDiv,
+                             G4double step, G4double offset,
+                             DivisionType divType, G4VSolid* motherSolid )
+  : faxis(axis), fnDiv( nDiv), fwidth(step), foffset(offset),
+    fDivisionType(divType), fmotherSolid( motherSolid ), fReflectedSolid(false),
+    fDeleteSolid(false), theVoluFirstCopyNo(1), fhgap(0.)
+{
+#ifdef G4DIVDEBUG
+  if (verbose >= 1)
+  {
+    G4cout << " G4VDivisionParameterisation  no divisions " << fnDiv
+           << " = " << nDiv << G4endl
+           << " offset " << foffset << " = " << offset << G4endl
+           << " step " << fwidth << " = " << step << G4endl;
+  }
+#endif
+  kCarTolerance = G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
+}
+
+//--------------------------------------------------------------------------
+G4VDivisionParameterisation::~G4VDivisionParameterisation()
+{
+  if (fDeleteSolid) delete fmotherSolid;
+}
+
+//--------------------------------------------------------------------------
+G4VSolid* 
+G4VDivisionParameterisation::
+ComputeSolid( const G4int i, G4VPhysicalVolume* pv )
+{
+  G4VSolid* solid = G4VPVParameterisation::ComputeSolid(i, pv);
+  if (solid->GetEntityType() == "G4ReflectedSolid")
+  {
+    solid = ((G4ReflectedSolid*)solid)->GetConstituentMovedSolid();
+  }
+  return solid;
+}      
+
+//--------------------------------------------------------------------------
+void
+G4VDivisionParameterisation::
+ChangeRotMatrix( G4VPhysicalVolume *physVol, G4double rotZ ) const
+{
+  static G4Mutex myMutex = G4MUTEX_INITIALIZER;
+  static std::map<int,std::map<void*,void*> > frotTable;
+
+  G4RotationMatrix *frot;
+  int threadId = G4Threading::G4GetThreadId();
+  if (threadId < 0) {
+    frot = physVol->GetRotation();
+  }
+  else {
+    G4AutoLock barrier(&myMutex);
+    frot = (G4RotationMatrix*)frotTable[threadId][physVol];
+    if (frot == 0) {
+      frot = new G4RotationMatrix();
+      physVol->SetRotation(frot);
+      frotTable[threadId][physVol] = frot;
+    }
+  }
+  *frot = G4RotationMatrix();
+  frot->rotateZ( rotZ );
+
+#if 0
+  G4AutoLock barrier(&myMutex);
+  static std::map<void*,void*> frot2physVol;
+  static std::map<void*,int> frot2threadId;
+  if (frot2physVol[frot] == 0) {
+    frot2physVol[frot] = physVol;
+    frot2threadId[frot] = threadId;
+  }
+  else if (frot2physVol[frot] != physVol || frot2threadId[frot] != threadId) {
+    G4cerr << "Hot diggitty dog!" << G4endl;
+    G4cerr << "  bad frot = " << frot << G4endl;
+    G4cerr << "  bad physVol = " << physVol << " =?= " << frot2physVol[frot] << G4endl;
+    G4cerr << "  bad threadId = " << threadId << " =?= " << frot2threadId[frot] << G4endl;
+    frot2physVol[frot] = physVol;
+    frot2threadId[frot] = threadId;
+  }
+#endif
+}
+
+//--------------------------------------------------------------------------
+G4int
+G4VDivisionParameterisation::
+CalculateNDiv( G4double motherDim, G4double width, G4double offset ) const
+{
+#ifdef G4DIVDEBUG
+  G4cout << " G4VDivisionParameterisation::CalculateNDiv: "
+         << ( motherDim - offset ) / width 
+         << " Motherdim: " <<  motherDim << ", Offset: " << offset
+         << ", Width: " << width << G4endl;
+#endif
+
+  return G4int( ( motherDim - offset ) / width );
+}
+
+//--------------------------------------------------------------------------
+G4double
+G4VDivisionParameterisation::
+CalculateWidth( G4double motherDim, G4int nDiv, G4double offset ) const
+{ 
+#ifdef G4DIVDEBUG
+  G4cout << " G4VDivisionParameterisation::CalculateWidth: "
+         << ( motherDim - offset ) / nDiv
+         << ", Motherdim: " << motherDim << ", Offset: " << offset
+         << ", Number of divisions: " << nDiv << G4endl;
+#endif
+
+  return ( motherDim - offset ) / nDiv;
+}
+
+//--------------------------------------------------------------------------
+void G4VDivisionParameterisation::CheckParametersValidity()
+{
+  G4double maxPar = GetMaxParameter();
+  CheckOffset( maxPar );
+  CheckNDivAndWidth( maxPar );
+}
+
+//--------------------------------------------------------------------------
+void G4VDivisionParameterisation::CheckOffset( G4double maxPar )
+{
+  if( foffset >= maxPar )
+  {
+    std::ostringstream message;
+    message << "Configuration not supported." << G4endl
+            << "Division of solid " << fmotherSolid->GetName()
+            << " has too big offset = " << G4endl
+            << "        " << foffset << " > " << maxPar << " !";
+    G4Exception("G4VDivisionParameterisation::CheckOffset()",
+                "GeomDiv0001", FatalException, message);
+  }
+}
+
+//--------------------------------------------------------------------------
+void G4VDivisionParameterisation::CheckNDivAndWidth( G4double maxPar )
+{
+  if( (fDivisionType == DivNDIVandWIDTH)
+      && (foffset + fwidth*fnDiv - maxPar > kCarTolerance ) )
+  {
+    std::ostringstream message;
+    message << "Configuration not supported." << G4endl
+            << "Division of solid " << fmotherSolid->GetName()
+           << " has too big offset + width*nDiv = " << G4endl
+           << "        " << foffset + fwidth*fnDiv << " > "
+           << foffset << ". Width = "
+           << G4endl
+           << "        " << fwidth << ". nDiv = " << fnDiv << " !";
+    G4Exception("G4VDivisionParameterisation::CheckNDivAndWidth()",
+                "GeomDiv0001", FatalException, message);
+  }
+}
+
+//--------------------------------------------------------------------------
+G4double G4VDivisionParameterisation::OffsetZ() const
+{
+  // take into account reflection in the offset
+  G4double offset = foffset;
+  if (fReflectedSolid) offset = GetMaxParameter() - fwidth*fnDiv - foffset; 
+
+  return offset;
+}  
+
+  

--- a/src/GlueXPhysicsList.cc
+++ b/src/GlueXPhysicsList.cc
@@ -184,9 +184,9 @@ void GlueXPhysicsList::ConstructProcess()
 #endif
 
    // create the special cuts processes and register them
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *mgr = particle->GetProcessManager();
       if (mgr == 0) {
@@ -341,9 +341,9 @@ void GlueXPhysicsList::SetCuts()
 
 void GlueXPhysicsList::ListActiveProcesses()
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4cout << particleName << ": ApplyCuts is " 
              << ((particle->GetApplyCutsFlag())? "on" : "off")
@@ -367,9 +367,9 @@ void GlueXPhysicsList::ListActiveProcesses()
 
 void GlueXPhysicsList::DoMultipleScattering(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -383,9 +383,9 @@ void GlueXPhysicsList::DoMultipleScattering(G4int flag)
 
 void GlueXPhysicsList::DoBremsstrahlung(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -399,9 +399,9 @@ void GlueXPhysicsList::DoBremsstrahlung(G4int flag)
 
 void GlueXPhysicsList::DoComptonScattering(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -415,9 +415,9 @@ void GlueXPhysicsList::DoComptonScattering(G4int flag)
 
 void GlueXPhysicsList::DoIonizationEnergyLoss(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -431,9 +431,9 @@ void GlueXPhysicsList::DoIonizationEnergyLoss(G4int flag)
 
 void GlueXPhysicsList::DoPairConversion(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -447,9 +447,9 @@ void GlueXPhysicsList::DoPairConversion(G4int flag)
 
 void GlueXPhysicsList::DoParticleDecay(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();
@@ -463,9 +463,9 @@ void GlueXPhysicsList::DoParticleDecay(G4int flag)
 
 void GlueXPhysicsList::DoHadronicInteractions(G4int flag)
 {
-   theParticleIterator->reset();
-   while ( (*theParticleIterator)() ) {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+   GetParticleIterator()->reset();
+   while ( (*GetParticleIterator())() ) {
+      G4ParticleDefinition* particle = GetParticleIterator()->value();
       G4String particleName = particle->GetParticleName();
       G4ProcessManager *pman = particle->GetProcessManager();
       G4ProcessVector *pvec = pman->GetProcessList();

--- a/src/GlueXSensitiveDetectorCDC.cc
+++ b/src/GlueXSensitiveDetectorCDC.cc
@@ -24,7 +24,7 @@
 
 #include <JANA/JApplication.h>
 
-#include <malloc.h>
+#include <stdlib.h>
 
 const double fC = 1e-15 * coulomb;
 const double GlueXSensitiveDetectorCDC::ELECTRON_CHARGE = 1.6022e-4*fC;

--- a/src/GlueXSensitiveDetectorFDC.cc
+++ b/src/GlueXSensitiveDetectorFDC.cc
@@ -24,7 +24,7 @@
 
 #include <JANA/JApplication.h>
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 const double fC = 1e-15 * coulomb;

--- a/src/GlueXTimer.cc
+++ b/src/GlueXTimer.cc
@@ -48,7 +48,11 @@ GlueXTimer::~GlueXTimer()
 void GlueXTimer::Reset() {
    int thread = G4Threading::G4GetThreadId() + 1;
    if (fIsRunning[thread]) {
+#ifndef CLOCK_THREAD_CPUTIME_ID
+      int err = -1;
+#else
       int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &fClock[thread]);
+#endif
       assert(err == 0);
       fTimeLastGo[thread] = fClock[thread].tv_sec + fClock[thread].tv_nsec*1e-9;
    }
@@ -63,7 +67,11 @@ void GlueXTimer::Start() {
              << G4endl;
    }
    else {
+#ifndef CLOCK_THREAD_CPUTIME_ID
+      int err = -1;
+#else
       int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &fClock[thread]);
+#endif
       assert(err == 0);
       fTimeLastGo[thread] = fClock[thread].tv_sec + fClock[thread].tv_nsec*1e-9;
       fRunningTotal[thread] = 0;
@@ -75,7 +83,11 @@ void GlueXTimer::Start() {
 void GlueXTimer::Stop() {
    int thread = G4Threading::G4GetThreadId() + 1;
    if (fIsRunning[thread]) {
+#ifndef CLOCK_THREAD_CPUTIME_ID
+      int err = -1;
+#else
       int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &fClock[thread]);
+#endif
       assert(err == 0);
       double now = fClock[thread].tv_sec + fClock[thread].tv_nsec*1e-9;
       fRunningTotal[thread] += now - fTimeLastGo[thread];
@@ -95,7 +107,11 @@ void GlueXTimer::Stop() {
 void GlueXTimer::Suspend() {
    int thread = G4Threading::G4GetThreadId() + 1;
    if (fIsRunning[thread]) {
+#ifndef CLOCK_THREAD_CPUTIME_ID
+      int err = -1;
+#else
       int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &fClock[thread]);
+#endif
       assert(err == 0);
       double now = fClock[thread].tv_sec + fClock[thread].tv_nsec*1e-9;
       fRunningTotal[thread] += now - fTimeLastGo[thread];
@@ -111,7 +127,11 @@ void GlueXTimer::Suspend() {
 void GlueXTimer::Resume() {
    int thread = G4Threading::G4GetThreadId() + 1;
    if (fIsStarted[thread] && !fIsRunning[thread]) {
+#ifndef CLOCK_THREAD_CPUTIME_ID
+      int err = -1;
+#else
       int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &fClock[thread]);
+#endif
       assert(err == 0);
       fTimeLastGo[thread] = fClock[thread].tv_sec + fClock[thread].tv_nsec*1e-9;
       fIsRunning[thread] = 1;

--- a/src/hdgeant4.cc
+++ b/src/hdgeant4.cc
@@ -128,6 +128,13 @@ int main(int argc,char** argv)
    G4RunManager runManager;
 #endif
 
+	// Let user turn off geometry optimization for faster startup
+	// (and slower running)
+	std::map<int, int> geomopt;
+	if ( opts.Find("GEOMOPT", geomopt) ) {
+         if( geomopt[1] == 0 ) runManager.SetGeometryToBeOptimized( false );
+	}
+
    // Geometry initialization
    GlueXDetectorConstruction *geometry = new GlueXDetectorConstruction();
    int Npara = geometry->GetParallelWorldCount();

--- a/test/control.in
+++ b/test/control.in
@@ -69,6 +69,14 @@ cGENBEAM 'postconv'
 c Commenting out the following line will disable simulated hits output.
 OUTFILE 'test4.hddm'
 
+c Uncomment the following line to turn off geometry optimization. Generally
+c you do NOT want to turn this off. Doing so may result in a significantly
+c faster startup, but slower event processing. Faster startup is useful
+c when running interactively to inspect the geometry or visualize a few
+c events. It may also be useful when developing HDGeant4 itself. Otherwise
+c leave geometry optimization on (the default).
+c GEOMOPT 0
+
 c The following are used to automatically invoke the mcsmear program
 c to do the final stage digitization of hits after the simulation
 c stage is complete. This simply invokes the mcsmear program passing


### PR DESCRIPTION
Here is the e-mail I originally sent to Richard on 4/11/2017 describing the changes in this branch:

--------------------------
Hi Richard,

 I spent a little time getting HDGeant4 to compile and run on Mac OS X. This required several
changes which I summarize below. I pushed the revisions to a branch named “davidl_OSX” 
in the JeffersonLab/HDGeant4 repository. I did not make an official pull request since I thought
you might want to take some time to review the changes and perhaps integrate the OS X parts
in a different way. The GNUmakefile in particular.

 I was able to compile and run hdgeant4 with the built-in particle gun generator and it produced
an hddm file which had something in it. I have not gone as far as checking the content in any
detail but expect that I have gotten past the biggest hurdles.

 I did this using Mac OS X 10.11 (El Capitan) which is one version behind the latest Mac OS X.
I also used the native compiler that comes with Xcode8. To get this to work though I had to move
up to Geant4 10.03.p01 (see below).


Here is a summary of the changes:

1. Created a separate GNUmakefile.OSX . Your original has several of ELF/Linux specific things 
in it. Pretty much anything using -Wl to pass special arguments to the linker will not be portable.
There weren’t too many changes, but enough that I wanted to let you decide how best to integrate
them. It’s possible we could just leave this as a separate makefile for OS X.

2. Disabled use of clock_gettime(CLOCK_THREAD_CPUTIME_ID, …) if CLOCK_THREAD_CPUTIME_ID
is not defined. Apparently this is present in the latest OS X (10.12) so I did it in such a way that
if CLOCK_THREAD_CPUTIME_ID is defined, then it will compile as you wrote it. Otherwise, 
it will compile it such that the assert will fail if that code is ever called.

3. Replaced #include <malloc.h> with #include <stdlib.h> which is apparently more generic.
OS X does not have malloc.h

4. Added a G4.10.03.p01fixes directory. I went to some trouble here to diff your fixes files with
the source from 10.02.p02 so I could see where you made the changes and then insert them
into the same files copied from the 10.03.p01 source. I believe these should be useful for compiling
on Linux as well. It was require for me though since I had to move up to 10.03.p01.

5. Added G4MTHepRandom.cc to the fixes directory. This was needed to resolve a strange run
time link error for G4MTHepRandom::getTheTableSeeds(long*, int). There is an extensive
comment at the top of the file. The bottom line though is that the meat of the file is only compiled
if __APPLE__ is defined so this shouldn’t affect other platforms.

6. Replaced “theParticleIterator” with “GetParticleIterator()” in GlueXPhysicsList.cc. This looks to
be a change from 10.02 to 10.03 so something more clever may need to be done if both versions
are to be simultaneously supported.

7. Added a README.OSX file. This is by no means exhaustive but wanted to document a few
tricks for others trying to get this running on OS X.

That’s it for now. I will be working off of this branch for the time being so if I come up with other
changes, I’ll let you know where I put them so you can merge them at your own pace.

Regards,
-David