### PR TITLE
* src/GlueXPrimaryGenerator.cc [rtj]

### DIFF
--- a/src/GlueXPrimaryGenerator.cc
+++ b/src/GlueXPrimaryGenerator.cc
@@ -68,10 +68,8 @@ void GlueXPrimaryGenerator::GeneratePrimaryVertex(G4Event *event)
          origin.setVy(y/cm);
          origin.setVz(z/cm);
       }
-      if (t == 0) {
-         t = GetParticleTime();
-         origin.setT(t/ns);
-      }
+      t += GetParticleTime();
+      origin.setT(t/ns);
       G4ThreeVector pos(x, y, z);
       G4PrimaryVertex* vertex = new G4PrimaryVertex(pos, t);
       hddm_s::ProductList &products = it_vertex->getProducts();


### PR DESCRIPTION
   - change the time-zero of tracks from vertex tags with origin time
     t > 0 to add the time offset of the zeroth vertex. Before this
     change, the beam-crossing t0 was added only if the origin time
     was zero in the MC record.