### PR TITLE
- add protection against race conditions during construction and

### DIFF
--- a/src/GlueXSensitiveDetectorBCAL.hh
+++ b/src/GlueXSensitiveDetectorBCAL.hh
@@ -29,7 +29,7 @@ class GlueXSensitiveDetectorBCAL : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorBCAL();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorBCAL : public G4VSensitiveDetector
    GlueXHitsMapBCALcell* fCellsMap;
    GlueXHitsMapBCALpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double THRESH_MEV;

--- a/src/GlueXSensitiveDetectorCCAL.hh
+++ b/src/GlueXSensitiveDetectorCCAL.hh
@@ -29,7 +29,7 @@ class GlueXSensitiveDetectorCCAL : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorCCAL();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorCCAL : public G4VSensitiveDetector
    GlueXHitsMapCCALblock* fBlocksMap;
    GlueXHitsMapCCALpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static int CENTRAL_COLUMN;

--- a/src/GlueXSensitiveDetectorCDC.hh
+++ b/src/GlueXSensitiveDetectorCDC.hh
@@ -31,7 +31,7 @@ class GlueXSensitiveDetectorCDC : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorCDC();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -47,7 +47,7 @@ class GlueXSensitiveDetectorCDC : public G4VSensitiveDetector
    GlueXHitsMapCDCstraw* fStrawsMap;
    GlueXHitsMapCDCpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static const double ELECTRON_CHARGE;
    static double DRIFT_SPEED;

--- a/src/GlueXSensitiveDetectorCERE.hh
+++ b/src/GlueXSensitiveDetectorCERE.hh
@@ -29,7 +29,7 @@ class GlueXSensitiveDetectorCERE : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorCERE();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorCERE : public G4VSensitiveDetector
    GlueXHitsMapCEREtube* fTubeHitsMap;
    GlueXHitsMapCEREpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double TWO_HIT_TIME_RESOL;

--- a/src/GlueXSensitiveDetectorDIRC.hh
+++ b/src/GlueXSensitiveDetectorDIRC.hh
@@ -35,7 +35,7 @@ class GlueXSensitiveDetectorDIRC : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorDIRC();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -46,7 +46,7 @@ class GlueXSensitiveDetectorDIRC : public G4VSensitiveDetector
   std::vector<GlueXHitDIRCBar> fHitsBar;
   std::vector<GlueXHitDIRCPmt> fHitsPmt;
   
-  static std::map<G4LogicalVolume*, int> fVolumeTable;
+  std::map<G4LogicalVolume*, int> fVolumeTable;
   
   static int MAX_HITS;
   // put all other detector response parameters here

--- a/src/GlueXSensitiveDetectorFCAL.cc
+++ b/src/GlueXSensitiveDetectorFCAL.cc
@@ -43,8 +43,6 @@ double GlueXSensitiveDetectorFCAL::THRESH_MEV = 5.;
 int GlueXSensitiveDetectorFCAL::instanceCount = 0;
 G4Mutex GlueXSensitiveDetectorFCAL::fMutex = G4MUTEX_INITIALIZER;
 
-std::map<G4LogicalVolume*, int> GlueXSensitiveDetectorFCAL::fVolumeTable;
-
 GlueXSensitiveDetectorFCAL::GlueXSensitiveDetectorFCAL(const G4String& name)
  : G4VSensitiveDetector(name),
    fBlocksMap(0), fPointsMap(0)
@@ -91,12 +89,14 @@ GlueXSensitiveDetectorFCAL::GlueXSensitiveDetectorFCAL(
  : G4VSensitiveDetector(src),
    fBlocksMap(src.fBlocksMap), fPointsMap(src.fPointsMap)
 {
+   G4AutoLock barrier(&fMutex);
    ++instanceCount;
 }
 
 GlueXSensitiveDetectorFCAL &GlueXSensitiveDetectorFCAL::operator=(const
                                          GlueXSensitiveDetectorFCAL &src)
 {
+   G4AutoLock barrier(&fMutex);
    *(G4VSensitiveDetector*)this = src;
    fBlocksMap = src.fBlocksMap;
    fPointsMap = src.fPointsMap;
@@ -105,6 +105,7 @@ GlueXSensitiveDetectorFCAL &GlueXSensitiveDetectorFCAL::operator=(const
 
 GlueXSensitiveDetectorFCAL::~GlueXSensitiveDetectorFCAL() 
 {
+   G4AutoLock barrier(&fMutex);
    --instanceCount;
 }
 
@@ -120,7 +121,7 @@ void GlueXSensitiveDetectorFCAL::Initialize(G4HCofThisEvent* hce)
 }
 
 G4bool GlueXSensitiveDetectorFCAL::ProcessHits(G4Step* step, 
-                                              G4TouchableHistory* unused)
+                                               G4TouchableHistory* ROhist)
 {
    double dEsum = step->GetTotalEnergyDeposit();
    const G4ThreeVector &pin = step->GetPreStepPoint()->GetMomentum();
@@ -374,7 +375,7 @@ void GlueXSensitiveDetectorFCAL::EndOfEvent(G4HCofThisEvent*)
 }
 
 int GlueXSensitiveDetectorFCAL::GetIdent(std::string div, 
-                                        const G4VTouchable *touch)
+                                         const G4VTouchable *touch)
 {
    const HddsG4Builder* bldr = GlueXDetectorConstruction::GetBuilder();
    std::map<std::string, std::vector<int> >::const_iterator iter;
@@ -390,10 +391,9 @@ int GlueXSensitiveDetectorFCAL::GetIdent(std::string div,
       }
       identifiers = &Refsys::fIdentifierTable[volId];
       if ((iter = identifiers->find(div)) != identifiers->end()) {
-         if (dynamic_cast<G4PVPlacement*>(pvol))
-            return iter->second[pvol->GetCopyNo() - 1];
-         else
-            return iter->second[pvol->GetCopyNo()];
+         int copyNum = touch->GetCopyNumber(depth);
+         copyNum += (dynamic_cast<G4PVPlacement*>(pvol))? -1 : 0;
+         return iter->second[copyNum];
       }
    }
    return -1;

--- a/src/GlueXSensitiveDetectorFCAL.hh
+++ b/src/GlueXSensitiveDetectorFCAL.hh
@@ -29,7 +29,7 @@ class GlueXSensitiveDetectorFCAL : public G4VSensitiveDetector
    virtual ~GlueXSensitiveDetectorFCAL();
   
    virtual void Initialize(G4HCofThisEvent* hitCollection);
-   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* unused);
+   virtual G4bool ProcessHits(G4Step* step, G4TouchableHistory* ROhist);
    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
 
    int GetIdent(std::string div, const G4VTouchable *touch);
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorFCAL : public G4VSensitiveDetector
    GlueXHitsMapFCALblock* fBlocksMap;
    GlueXHitsMapFCALpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static int CENTRAL_COLUMN;

--- a/src/GlueXSensitiveDetectorFDC.hh
+++ b/src/GlueXSensitiveDetectorFDC.hh
@@ -61,7 +61,7 @@ class GlueXSensitiveDetectorFDC : public G4VSensitiveDetector
    GlueXHitsMapFDCcathode* fCathodesMap;
    GlueXHitsMapFDCpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static const double ELECTRON_CHARGE;
    static double DRIFT_SPEED;

--- a/src/GlueXSensitiveDetectorFMWPC.hh
+++ b/src/GlueXSensitiveDetectorFMWPC.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorFMWPC : public G4VSensitiveDetector
    GlueXHitsMapFMWPCwire* fWireHitsMap;
    GlueXHitsMapFMWPCpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double TWO_HIT_TIME_RESOL;

--- a/src/GlueXSensitiveDetectorFTOF.cc
+++ b/src/GlueXSensitiveDetectorFTOF.cc
@@ -43,8 +43,6 @@ double GlueXSensitiveDetectorFTOF::THRESH_MEV = 0.;
 int GlueXSensitiveDetectorFTOF::instanceCount = 0;
 G4Mutex GlueXSensitiveDetectorFTOF::fMutex = G4MUTEX_INITIALIZER;
 
-std::map<G4LogicalVolume*, int> GlueXSensitiveDetectorFTOF::fVolumeTable;
-
 GlueXSensitiveDetectorFTOF::GlueXSensitiveDetectorFTOF(const G4String& name)
  : G4VSensitiveDetector(name),
    fBarHitsMap(0), fPointsMap(0)
@@ -88,12 +86,14 @@ GlueXSensitiveDetectorFTOF::GlueXSensitiveDetectorFTOF(
  : G4VSensitiveDetector(src),
    fBarHitsMap(src.fBarHitsMap), fPointsMap(src.fPointsMap)
 {
+   G4AutoLock barrier(&fMutex);
    ++instanceCount;
 }
 
 GlueXSensitiveDetectorFTOF &GlueXSensitiveDetectorFTOF::operator=(const
                                          GlueXSensitiveDetectorFTOF &src)
 {
+   G4AutoLock barrier(&fMutex);
    *(G4VSensitiveDetector*)this = src;
    fBarHitsMap = src.fBarHitsMap;
    fPointsMap = src.fPointsMap;
@@ -102,6 +102,7 @@ GlueXSensitiveDetectorFTOF &GlueXSensitiveDetectorFTOF::operator=(const
 
 GlueXSensitiveDetectorFTOF::~GlueXSensitiveDetectorFTOF() 
 {
+   G4AutoLock barrier(&fMutex);
    --instanceCount;
 }
 
@@ -117,7 +118,7 @@ void GlueXSensitiveDetectorFTOF::Initialize(G4HCofThisEvent* hce)
 }
 
 G4bool GlueXSensitiveDetectorFTOF::ProcessHits(G4Step* step, 
-                                              G4TouchableHistory* unused)
+                                               G4TouchableHistory* ROhist)
 {
    double dEsum = step->GetTotalEnergyDeposit();
    if (dEsum == 0)
@@ -523,10 +524,9 @@ int GlueXSensitiveDetectorFTOF::GetIdent(std::string div,
       }
       identifiers = &Refsys::fIdentifierTable[volId];
       if ((iter = identifiers->find(div)) != identifiers->end()) {
-         if (dynamic_cast<G4PVPlacement*>(pvol))
-            return iter->second[pvol->GetCopyNo() - 1];
-         else
-            return iter->second[pvol->GetCopyNo()];
+         int copyNum = touch->GetCopyNumber(depth);
+         copyNum += (dynamic_cast<G4PVPlacement*>(pvol))? -1 : 0;
+         return iter->second[copyNum];
       }
    }
    return -1;

--- a/src/GlueXSensitiveDetectorFTOF.hh
+++ b/src/GlueXSensitiveDetectorFTOF.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorFTOF : public G4VSensitiveDetector
    GlueXHitsMapFTOFbar* fBarHitsMap;
    GlueXHitsMapFTOFpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static int MAX_HITS_PER_BAR;

--- a/src/GlueXSensitiveDetectorGCAL.hh
+++ b/src/GlueXSensitiveDetectorGCAL.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorGCAL : public G4VSensitiveDetector
    GlueXHitsMapGCALblock* fBlockHitsMap;
    GlueXHitsMapGCALpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double ATTENUATION_LENGTH;

--- a/src/GlueXSensitiveDetectorPS.hh
+++ b/src/GlueXSensitiveDetectorPS.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorPS : public G4VSensitiveDetector
    GlueXHitsMapPStile* fTileHitsMap;
    GlueXHitsMapPSpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static int NUM_COLUMNS_PER_ARM;

--- a/src/GlueXSensitiveDetectorPSC.hh
+++ b/src/GlueXSensitiveDetectorPSC.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorPSC : public G4VSensitiveDetector
    GlueXHitsMapPSCpaddle* fCounterHitsMap;
    GlueXHitsMapPSCpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static int NUM_MODULES_PER_ARM;

--- a/src/GlueXSensitiveDetectorSTC.cc
+++ b/src/GlueXSensitiveDetectorSTC.cc
@@ -58,8 +58,6 @@ double GlueXSensitiveDetectorSTC::THRESH_MEV = 0.150;
 int GlueXSensitiveDetectorSTC::instanceCount = 0;
 G4Mutex GlueXSensitiveDetectorSTC::fMutex = G4MUTEX_INITIALIZER;
 
-std::map<G4LogicalVolume*, int> GlueXSensitiveDetectorSTC::fVolumeTable;
-
 GlueXSensitiveDetectorSTC::GlueXSensitiveDetectorSTC(const G4String& name)
  : G4VSensitiveDetector(name),
    fHitsMap(0), fPointsMap(0)
@@ -134,12 +132,14 @@ GlueXSensitiveDetectorSTC::GlueXSensitiveDetectorSTC(
  : G4VSensitiveDetector(src),
    fHitsMap(src.fHitsMap), fPointsMap(src.fPointsMap)
 {
+   G4AutoLock barrier(&fMutex);
    ++instanceCount;
 }
 
 GlueXSensitiveDetectorSTC &GlueXSensitiveDetectorSTC::operator=(const
                                          GlueXSensitiveDetectorSTC &src)
 {
+   G4AutoLock barrier(&fMutex);
    *(G4VSensitiveDetector*)this = src;
    fHitsMap = src.fHitsMap;
    fPointsMap = src.fPointsMap;
@@ -148,6 +148,7 @@ GlueXSensitiveDetectorSTC &GlueXSensitiveDetectorSTC::operator=(const
 
 GlueXSensitiveDetectorSTC::~GlueXSensitiveDetectorSTC() 
 {
+   G4AutoLock barrier(&fMutex);
    --instanceCount;
 }
 
@@ -163,7 +164,7 @@ void GlueXSensitiveDetectorSTC::Initialize(G4HCofThisEvent* hce)
 }
 
 G4bool GlueXSensitiveDetectorSTC::ProcessHits(G4Step* step, 
-                                              G4TouchableHistory* unused)
+                                              G4TouchableHistory* ROhist)
 {
    double dEsum = step->GetTotalEnergyDeposit();
    if (dEsum == 0)
@@ -435,10 +436,9 @@ int GlueXSensitiveDetectorSTC::GetIdent(std::string div,
       }
       identifiers = &Refsys::fIdentifierTable[volId];
       if ((iter = identifiers->find(div)) != identifiers->end()) {
-         if (dynamic_cast<G4PVPlacement*>(pvol))
-            return iter->second[pvol->GetCopyNo() - 1];
-         else
-            return iter->second[pvol->GetCopyNo()];
+         int copyNum = touch->GetCopyNumber(depth);
+         copyNum += (dynamic_cast<G4PVPlacement*>(pvol))? -1 : 0;
+         return iter->second[copyNum];
       }
    }
    return -1;

--- a/src/GlueXSensitiveDetectorSTC.hh
+++ b/src/GlueXSensitiveDetectorSTC.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorSTC : public G4VSensitiveDetector
    GlueXHitsMapSTCpaddle* fHitsMap;
    GlueXHitsMapSTCpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double ATTENUATION_LENGTH;

--- a/src/GlueXSensitiveDetectorTPOL.cc
+++ b/src/GlueXSensitiveDetectorTPOL.cc
@@ -34,8 +34,6 @@ double GlueXSensitiveDetectorTPOL::THRESH_MEV = 0.050;
 int GlueXSensitiveDetectorTPOL::instanceCount = 0;
 G4Mutex GlueXSensitiveDetectorTPOL::fMutex = G4MUTEX_INITIALIZER;
 
-std::map<G4LogicalVolume*, int> GlueXSensitiveDetectorTPOL::fVolumeTable;
-
 GlueXSensitiveDetectorTPOL::GlueXSensitiveDetectorTPOL(const G4String& name)
  : G4VSensitiveDetector(name),
    fHitsMap(0), fPointsMap(0)
@@ -72,12 +70,14 @@ GlueXSensitiveDetectorTPOL::GlueXSensitiveDetectorTPOL(
  : G4VSensitiveDetector(src),
    fHitsMap(src.fHitsMap), fPointsMap(src.fPointsMap)
 {
+   G4AutoLock barrier(&fMutex);
    ++instanceCount;
 }
 
 GlueXSensitiveDetectorTPOL &GlueXSensitiveDetectorTPOL::operator=(const
                                          GlueXSensitiveDetectorTPOL &src)
 {
+   G4AutoLock barrier(&fMutex);
    *(G4VSensitiveDetector*)this = src;
    fHitsMap = src.fHitsMap;
    fPointsMap = src.fPointsMap;
@@ -86,6 +86,7 @@ GlueXSensitiveDetectorTPOL &GlueXSensitiveDetectorTPOL::operator=(const
 
 GlueXSensitiveDetectorTPOL::~GlueXSensitiveDetectorTPOL() 
 {
+   G4AutoLock barrier(&fMutex);
    --instanceCount;
 }
 
@@ -101,7 +102,7 @@ void GlueXSensitiveDetectorTPOL::Initialize(G4HCofThisEvent* hce)
 }
 
 G4bool GlueXSensitiveDetectorTPOL::ProcessHits(G4Step* step, 
-                                               G4TouchableHistory* unused)
+                                               G4TouchableHistory* ROhist)
 {
    double dEsum = step->GetTotalEnergyDeposit();
    if (dEsum == 0)
@@ -330,10 +331,9 @@ int GlueXSensitiveDetectorTPOL::GetIdent(std::string div,
       }
       identifiers = &Refsys::fIdentifierTable[volId];
       if ((iter = identifiers->find(div)) != identifiers->end()) {
-         if (dynamic_cast<G4PVPlacement*>(pvol))
-            return iter->second[pvol->GetCopyNo() - 1];
-         else
-            return iter->second[pvol->GetCopyNo()];
+         int copyNum = touch->GetCopyNumber(depth);
+         copyNum += (dynamic_cast<G4PVPlacement*>(pvol))? -1 : 0;
+         return iter->second[copyNum];
       }
    }
    return -1;

--- a/src/GlueXSensitiveDetectorTPOL.hh
+++ b/src/GlueXSensitiveDetectorTPOL.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorTPOL : public G4VSensitiveDetector
    GlueXHitsMapTPOLwedge* fHitsMap;
    GlueXHitsMapTPOLpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double TWO_HIT_TIME_RESOL;

--- a/src/GlueXSensitiveDetectorUPV.hh
+++ b/src/GlueXSensitiveDetectorUPV.hh
@@ -38,7 +38,7 @@ class GlueXSensitiveDetectorUPV : public G4VSensitiveDetector
    GlueXHitsMapUPVbar* fBarHitsMap;
    GlueXHitsMapUPVpoint* fPointsMap;
 
-   static std::map<G4LogicalVolume*, int> fVolumeTable;
+   std::map<G4LogicalVolume*, int> fVolumeTable;
 
    static int MAX_HITS;
    static double ATTENUATION_LENGTH;


### PR DESCRIPTION
  destruction of sensitive detectors in multiple threads [rtj]
- get volume copy number from the private pre/post step object,
  not from the shared geometry objects that get overwritten by
  other threads [rtj]
- make the logical volume lookup table private to each thread, to
  avoid possible std::map corruption from simultaneous modification
  by more than one thread [rtj]
- change the name of the second argument to ProcessHits methods to
  ROhist (readout history) because this is NOT a pointer to the
  current touchable in the standard geometry; it is used in special
  cases with a "readout" geometry different from the standard one.